### PR TITLE
Integration test suite using maildir backend

### DIFF
--- a/.mise/tasks/test-integration
+++ b/.mise/tasks/test-integration
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Run integration tests (maildir-backed, no network)"
+
+set -e
+
+export MISE_CONFIG_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bats test/integration/

--- a/README.tsx
+++ b/README.tsx
@@ -1,0 +1,221 @@
+/** @jsxImportSource jsx-md */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, resolve } from "path";
+
+import {
+  Heading, Paragraph, CodeBlock, LineBreak,
+  Bold, Code, Link,
+  Badge, Badges, Center, Section,
+  Table, TableHead, TableRow, Cell,
+  List, Item, Raw, Sub, HR,
+} from "readme/src/components";
+
+// ── Dynamic data ─────────────────────────────────────────────
+
+const REPO_DIR = resolve(import.meta.dirname);
+const TASK_DIR = join(REPO_DIR, ".mise/tasks");
+const TEST_DIR = join(REPO_DIR, "test");
+
+// Parse commands from task files
+interface Command {
+  name: string;
+  description: string;
+}
+
+function parseTask(name: string): Command {
+  const src = readFileSync(join(TASK_DIR, name), "utf-8");
+  const desc = src.match(/#MISE description="(.+)"/)?.[1] ?? "";
+  return { name, description: desc };
+}
+
+const commands = readdirSync(TASK_DIR)
+  .filter((f) => !f.startsWith("_") && !f.startsWith(".") && f !== "test" && f !== "test-integration")
+  .map(parseTask)
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+// Count tests
+function countTests(dir: string): number {
+  if (!existsSync(dir)) return 0;
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".bats"))
+    .reduce((sum, f) => {
+      const content = readFileSync(join(dir, f), "utf-8");
+      return sum + (content.match(/@test /g)?.length ?? 0);
+    }, 0);
+}
+
+const unitTests = countTests(TEST_DIR);
+const integrationTests = countTests(join(TEST_DIR, "integration"));
+const totalTests = unitTests + integrationTests;
+
+// ── README ───────────────────────────────────────────────────
+
+const readme = (
+  <>
+    <Center>
+      <Heading level={1}>emails</Heading>
+
+      <Paragraph>
+        <Bold>Email tooling for agents.</Bold>
+      </Paragraph>
+
+      <Paragraph>
+        {"Wraps "}
+        <Link href="https://github.com/pimalaya/himalaya">himalaya</Link>
+        {" with agent identity, GPG signing, and quota management."}
+      </Paragraph>
+
+      <Badges>
+        <Badge label="shell" value="bash" color="4EAA25" logo="gnubash" logoColor="white" />
+        <Badge label="runtime" value="mise" color="7c3aed" href="https://mise.jdx.dev" />
+        <Badge label="commands" value={`${commands.length}`} color="blue" />
+        <Badge label="tests" value={`${totalTests} passing`} color="brightgreen" href="test/" />
+        <Badge label="License" value="MIT" color="blue" href="LICENSE" />
+      </Badges>
+    </Center>
+
+    <Section title="Install">
+      <CodeBlock lang="bash">{`shiv install emails`}</CodeBlock>
+
+      <Paragraph>
+        {"First-time setup for an agent:"}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`emails setup <agent-name>`}</CodeBlock>
+    </Section>
+
+    <Section title="Quick start">
+      <CodeBlock lang="bash">{`# Check inbox
+emails list
+
+# Read a message
+emails read <id>
+
+# Send a GPG-signed email
+emails send user@example.com "Subject" "Message body here."
+
+# Reply to a message
+emails reply <id> "Thanks, got it."
+
+# Overview and status
+emails welcome`}</CodeBlock>
+    </Section>
+
+    <Section title="Commands">
+      <Table>
+        <TableHead>
+          <Cell>Command</Cell>
+          <Cell>Description</Cell>
+        </TableHead>
+        {commands.map((cmd) => (
+          <TableRow>
+            <Cell><Code>{`emails ${cmd.name}`}</Code></Cell>
+            <Cell>{cmd.description}</Cell>
+          </TableRow>
+        ))}
+      </Table>
+    </Section>
+
+    <Section title="HTML email">
+      <Paragraph>
+        {"Send and reply support "}
+        <Code>--html</Code>
+        {" for HTML content:"}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`# Send HTML email
+emails send user@example.com "Subject" --html -b /path/to/email.html
+
+# Pipe HTML
+cat email.html | emails send user@example.com "Subject" --html
+
+# Reply with HTML
+emails reply 42 --html -b '<h1>Thanks!</h1><p>Got it.</p>'`}</CodeBlock>
+    </Section>
+
+    <Section title="GPG signing">
+      <Paragraph>
+        {"All outgoing messages are GPG-signed automatically using the agent's key. "}
+        {"This provides a unified cryptographic identity — the same key signs git commits and emails."}
+      </Paragraph>
+
+      <Paragraph>
+        {"Incoming messages show signature status when read:"}
+      </Paragraph>
+
+      <CodeBlock>{`From: brownie@ricon.family (✓ Signed by brownie <brownie@ricon.family>)
+From: unknown@example.com (⚠ Unsigned)
+From: imposter@ricon.family (✗ Bad signature)`}</CodeBlock>
+    </Section>
+
+    <Section title="Body input">
+      <Paragraph>
+        {"Messages accept body content three ways:"}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`# Positional argument
+emails send user@example.com "Subject" "Inline body text."
+
+# Flag (or file path)
+emails send user@example.com "Subject" -b "Flag body text."
+emails send user@example.com "Subject" -b /path/to/body.txt
+
+# Stdin
+echo "Piped body." | emails send user@example.com "Subject"`}</CodeBlock>
+
+      <Paragraph>
+        {"A minimum body length of 50 characters guards against accidental sends. "}
+        {"Override with "}
+        <Code>--allow-short</Code>
+        {"."}
+      </Paragraph>
+    </Section>
+
+    <Section title="Testing">
+      <Paragraph>
+        {`${totalTests} tests across two suites:`}
+      </Paragraph>
+
+      <List>
+        <Item>
+          <Bold>{`Unit tests (${unitTests})`}</Bold>
+          {" — mock himalaya, test task logic in isolation"}
+        </Item>
+        <Item>
+          <Bold>{`Integration tests (${integrationTests})`}</Bold>
+          {" — real himalaya against a local maildir backend, full round-trip"}
+        </Item>
+      </List>
+
+      <CodeBlock lang="bash">{`mise run test              # unit tests
+mise run test-integration  # integration tests (maildir-backed, no network)`}</CodeBlock>
+    </Section>
+
+    <Section title="Development">
+      <CodeBlock lang="bash">{`git clone https://github.com/KnickKnackLabs/emails.git
+cd emails && mise trust && mise install
+mise run test`}</CodeBlock>
+
+      <Paragraph>
+        {"Requires "}
+        <Link href="https://github.com/pimalaya/himalaya">himalaya</Link>
+        {" and a GPG key configured for the agent."}
+      </Paragraph>
+    </Section>
+
+    <LineBreak />
+
+    <Center>
+      <HR />
+
+      <Sub>
+        {"This README was generated from "}
+        <Link href="https://github.com/KnickKnackLabs/readme">README.tsx</Link>
+        {"."}
+      </Sub>
+    </Center>
+  </>
+);
+
+console.log(readme);

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -1,0 +1,128 @@
+# Integration test helpers for emails
+#
+# Uses himalaya's maildir backend + sendmail for a fully local test environment.
+# No network daemons needed — all I/O is filesystem-based.
+#
+# Provides:
+#   - setup_maildir()     — creates maildir folders + himalaya config + fake sendmail
+#   - deposit_message()   — drops a raw message into a maildir folder
+#   - emails()            — runs emails tasks via mise with test config
+#   - MAILDIR_ROOT        — path to the test maildir
+
+if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
+  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test:integration" >&2
+  exit 1
+fi
+
+emails() {
+  cd "$MISE_CONFIG_ROOT" && mise run -q "$@"
+}
+export -f emails
+
+# Create a maildir test environment matching our mxroute folder structure.
+# Sets: MAILDIR_ROOT, HIMALAYA_CONFIG, AGENT, GIT_AUTHOR_EMAIL, FAKE_SENDMAIL_MAILDIR
+setup_maildir() {
+  export MAILDIR_ROOT="$BATS_TEST_TMPDIR/maildir"
+  export AGENT="test-agent"
+  export GIT_AUTHOR_EMAIL="test-agent@ricon.family"
+
+  # Create maildir folder structure (INBOX, Sent, Trash, Archive)
+  for folder in INBOX Sent Trash Archive Drafts; do
+    mkdir -p "$MAILDIR_ROOT/$folder"/{cur,new,tmp}
+  done
+
+  # Fake sendmail: deposits messages into INBOX/new (simulates delivery)
+  local sendmail="$BATS_TEST_TMPDIR/fake-sendmail.sh"
+  cat > "$sendmail" << 'SCRIPT'
+#!/usr/bin/env bash
+DEST="$FAKE_SENDMAIL_MAILDIR/INBOX/new/$(date +%s).${RANDOM}.$$:2,"
+cat > "$DEST"
+SCRIPT
+  chmod +x "$sendmail"
+  export FAKE_SENDMAIL_MAILDIR="$MAILDIR_ROOT"
+
+  # Himalaya config: maildir backend + sendmail for sending
+  export HIMALAYA_CONFIG="$BATS_TEST_TMPDIR/himalaya-config.toml"
+  cat > "$HIMALAYA_CONFIG" << EOF
+[accounts.test-agent]
+default = true
+email = "test-agent@ricon.family"
+display-name = "Test Agent"
+
+backend.type = "maildir"
+backend.root-dir = "$MAILDIR_ROOT"
+
+message.send.backend.type = "sendmail"
+message.send.backend.cmd = "$sendmail"
+
+pgp.type = "commands"
+pgp.sign-cmd = "gpg --sign --quiet --armor"
+pgp.decrypt-cmd = "gpg --decrypt --quiet"
+pgp.verify-cmd = "gpg --verify --quiet"
+EOF
+
+  # Agent workspace for attachment downloads
+  mkdir -p "$HOME/agents/test-agent/downloads"
+}
+
+# Deposit a raw email into a maildir folder.
+# Usage: deposit_message [--folder FOLDER] [--from FROM] [--subject SUBJECT] [--body BODY]
+# Defaults: folder=INBOX, from=sender@example.com, subject=Test, body=...
+deposit_message() {
+  local folder="INBOX"
+  local from="sender@example.com"
+  local to="test-agent@ricon.family"
+  local subject="Test message"
+  local body="This is a test message with sufficient body content for testing purposes."
+  local message_id=""
+  local date=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --folder)  folder="$2"; shift 2 ;;
+      --from)    from="$2"; shift 2 ;;
+      --to)      to="$2"; shift 2 ;;
+      --subject) subject="$2"; shift 2 ;;
+      --body)    body="$2"; shift 2 ;;
+      --message-id) message_id="$2"; shift 2 ;;
+      --date)    date="$2"; shift 2 ;;
+      *) echo "Unknown arg: $1" >&2; return 1 ;;
+    esac
+  done
+
+  [ -z "$message_id" ] && message_id="<$(date +%s).$RANDOM@test>"
+  [ -z "$date" ] && date="$(date -R 2>/dev/null || date '+%a, %d %b %Y %H:%M:%S %z')"
+
+  local filename
+  filename="$(date +%s).${RANDOM}.$$:2,"
+
+  cat > "$MAILDIR_ROOT/$folder/new/$filename" << EOF
+From: $from
+To: $to
+Subject: $subject
+Date: $date
+Message-ID: $message_id
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+$body
+EOF
+
+  # Return the filename for reference
+  echo "$filename"
+}
+
+# Count messages in a maildir folder (cur + new)
+maildir_count() {
+  local folder="${1:-INBOX}"
+  local count=0
+  count=$(find "$MAILDIR_ROOT/$folder/cur" "$MAILDIR_ROOT/$folder/new" -type f 2>/dev/null | wc -l | tr -d ' ')
+  echo "$count"
+}
+
+# Get the envelope ID of the most recent message via himalaya
+latest_envelope_id() {
+  local folder="${1:-INBOX}"
+  himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f "$folder" --page-size 1 2>/dev/null \
+    | tail -n +4 | head -1 | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}'
+}

--- a/test/integration/archive.bats
+++ b/test/integration/archive.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "archive: moves message to Archive folder" {
+  deposit_message --subject "Archive me"
+
+  local id
+  id=$(latest_envelope_id)
+
+  run emails archive "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Archived"* ]]
+
+  # Gone from INBOX
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [[ "$output" != *"Archive me"* ]]
+
+  # Present in Archive
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Archive --page-size 100 2>/dev/null
+  [[ "$output" == *"Archive me"* ]]
+}

--- a/test/integration/delete.bats
+++ b/test/integration/delete.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "delete: moves message to Trash" {
+  deposit_message --subject "Delete me"
+
+  local id
+  id=$(latest_envelope_id)
+
+  run emails delete "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Moved"* ]]
+  [[ "$output" == *"Trash"* ]]
+
+  # Gone from INBOX
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [[ "$output" != *"Delete me"* ]]
+
+  # Present in Trash
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Trash --page-size 100 2>/dev/null
+  [[ "$output" == *"Delete me"* ]]
+}
+
+@test "delete: permanent delete removes message entirely" {
+  deposit_message --subject "Destroy me"
+
+  local id
+  id=$(latest_envelope_id)
+
+  run emails delete --permanent "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Permanently deleted"* ]]
+
+  # Gone from INBOX
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [[ "$output" != *"Destroy me"* ]]
+
+  # Not in Trash either
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Trash --page-size 100 2>/dev/null
+  [[ "$output" != *"Destroy me"* ]]
+}
+
+@test "delete: refuses to move Trash messages to Trash" {
+  deposit_message --folder Trash --subject "Already trashed"
+
+  local id
+  id=$(latest_envelope_id Trash)
+
+  run emails delete -f Trash "$id"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Cannot move Trash"* ]]
+}
+
+@test "delete: --all deletes all messages in folder" {
+  deposit_message --subject "Bulk one"
+  deposit_message --subject "Bulk two"
+  deposit_message --subject "Bulk three"
+
+  run emails delete --all
+  [ "$status" -eq 0 ]
+
+  # INBOX should be empty
+  [ "$(maildir_count INBOX)" -eq 0 ]
+
+  # All three should be in Trash
+  [ "$(maildir_count Trash)" -eq 3 ]
+}

--- a/test/integration/list.bats
+++ b/test/integration/list.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "list: shows deposited messages" {
+  deposit_message --subject "First message"
+  deposit_message --subject "Second message"
+
+  run emails list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First message"* ]]
+  [[ "$output" == *"Second message"* ]]
+}
+
+@test "list: respects --limit flag" {
+  for i in 1 2 3 4 5; do
+    deposit_message --subject "Message $i"
+  done
+
+  run emails list -n 2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"more available"* ]]
+}
+
+@test "list: shows different folders" {
+  deposit_message --folder INBOX --subject "Inbox msg"
+  deposit_message --folder Trash --subject "Trash msg"
+
+  run emails list -f INBOX
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Inbox msg"* ]]
+  [[ "$output" != *"Trash msg"* ]]
+
+  run emails list -f Trash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Trash msg"* ]]
+  [[ "$output" != *"Inbox msg"* ]]
+}
+
+@test "list: --count returns message count" {
+  deposit_message --subject "One"
+  deposit_message --subject "Two"
+  deposit_message --subject "Three"
+
+  run emails list --count
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"3"* ]]
+}
+
+@test "list: empty folder shows no messages" {
+  run emails list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SUBJECT"* ]]
+}

--- a/test/integration/read.bats
+++ b/test/integration/read.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "read: displays message content" {
+  deposit_message --subject "Read me" --body "This is the body of the message to be read in the integration test."
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Read me"* ]]
+  [[ "$output" == *"body of the message"* ]]
+}
+
+@test "read: shows sender information" {
+  deposit_message --from "alice@example.com" --subject "From Alice"
+
+  local id
+  id=$(latest_envelope_id)
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alice@example.com"* ]]
+}
+
+@test "read: works with different folders" {
+  deposit_message --folder Trash --subject "Trashed message" \
+    --body "This message lives in the Trash folder and should be readable from there."
+
+  local id
+  id=$(latest_envelope_id Trash)
+
+  run emails read "$id" -f Trash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Trashed message"* ]]
+}
+
+@test "read: nonexistent message returns empty output" {
+  # NOTE: read currently exits 0 for nonexistent messages because himalaya's
+  # error is swallowed by the sed pipe. This tests current behavior — fixing
+  # the exit code is tracked separately.
+  run emails read 99999
+  # Output should contain the error or be mostly empty (no message content)
+  [[ "$output" != *"Subject:"* ]]
+}

--- a/test/integration/roundtrip.bats
+++ b/test/integration/roundtrip.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "roundtrip: send → list → read → delete → verify" {
+  # Send
+  emails send test-agent@ricon.family "Round trip test" \
+    "This message exercises the full lifecycle: send, list, read, and delete."
+
+  # List — message appears in INBOX (via fake sendmail delivery)
+  run emails list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Round trip test"* ]]
+
+  # Get the ID
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || fail "no message found after send"
+
+  # Read
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"full lifecycle"* ]]
+
+  # Delete (move to Trash)
+  run emails delete "$id"
+  [ "$status" -eq 0 ]
+
+  # Verify: gone from INBOX
+  run emails list
+  [[ "$output" != *"Round trip test"* ]]
+
+  # Verify: in Trash
+  run emails list -f Trash
+  [[ "$output" == *"Round trip test"* ]]
+}
+
+@test "roundtrip: send → archive" {
+  emails send test-agent@ricon.family "Archive after send" \
+    "This message will be archived immediately after being received in the inbox."
+
+  local id
+  id=$(latest_envelope_id)
+
+  emails archive "$id"
+
+  # Gone from INBOX
+  run emails list
+  [[ "$output" != *"Archive after send"* ]]
+
+  # In Archive
+  run emails list -f Archive
+  [[ "$output" == *"Archive after send"* ]]
+}
+
+@test "roundtrip: multiple messages maintain isolation" {
+  deposit_message --subject "Message A" --from "alice@example.com"
+  deposit_message --subject "Message B" --from "bob@example.com"
+
+  # Both visible
+  run emails list
+  [[ "$output" == *"Message A"* ]]
+  [[ "$output" == *"Message B"* ]]
+
+  # Delete just the first one
+  local ids
+  ids=$(himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null \
+    | tail -n +4 | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}' | grep -E '^[0-9]+$')
+
+  local first_id
+  first_id=$(echo "$ids" | head -1)
+
+  emails delete "$first_id"
+
+  # One remains in INBOX
+  [ "$(maildir_count INBOX)" -ge 1 ]
+}

--- a/test/integration/send.bats
+++ b/test/integration/send.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load ../integration-helpers
+  setup_maildir
+}
+
+@test "send: delivers message to recipient inbox" {
+  emails send test-agent@ricon.family "Integration test" \
+    "This is a test message sent through the integration test suite for validation." \
+    --allow-short
+
+  # Message should appear in INBOX (delivered by fake sendmail)
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Integration test"* ]]
+}
+
+@test "send: saves copy to Sent folder" {
+  emails send test-agent@ricon.family "Sent copy test" \
+    "Verifying that a copy of the sent message appears in the Sent folder automatically."
+
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Sent --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent copy test"* ]]
+}
+
+@test "send: GPG-signs messages" {
+  emails send test-agent@ricon.family "Signed message test" \
+    "This message should be GPG-signed automatically by the send task in the emails package."
+
+  # GPG-signed messages show @ flag (signature is a MIME attachment)
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Sent --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"@"* ]]
+}
+
+@test "send: rejects empty body" {
+  run emails send test-agent@ricon.family "Empty body test" </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "send: rejects short body without --allow-short" {
+  run emails send test-agent@ricon.family "Short body test" "too short"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"too short"* ]]
+}
+
+@test "send: accepts short body with --allow-short" {
+  run emails send test-agent@ricon.family "Short allowed" "short body" --allow-short
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to"* ]]
+}
+
+@test "send: reads body from stdin" {
+  echo "This is a message body piped through stdin for the integration test suite to verify." \
+    | emails send test-agent@ricon.family "Stdin test"
+
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Stdin test"* ]]
+}
+
+@test "send: reads body from file via -b flag" {
+  local bodyfile="$BATS_TEST_TMPDIR/body.txt"
+  echo "This is the message body loaded from a file path passed via the -b flag for testing." > "$bodyfile"
+
+  emails send test-agent@ricon.family "File body test" -b "$bodyfile"
+
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"File body test"* ]]
+}
+
+@test "send: html flag sends as html content type" {
+  local htmlfile="$BATS_TEST_TMPDIR/email.html"
+  cat > "$htmlfile" << 'HTML'
+<html><body><h1>Hello</h1><p>This is an HTML email sent through the integration test suite.</p></body></html>
+HTML
+
+  emails send test-agent@ricon.family "HTML test" --html -b "$htmlfile"
+
+  # Verify the raw message in Sent has text/html
+  local sent_msg
+  sent_msg=$(find "$MAILDIR_ROOT/Sent" -type f | head -1)
+  run cat "$sent_msg"
+  [[ "$output" == *"text/html"* ]]
+}


### PR DESCRIPTION
Uses himalaya's maildir backend + sendmail for a fully local test environment. No network daemons needed — all I/O is filesystem-based.

## Approach

Folder structure mirrors our mxroute setup (INBOX, Sent, Trash, Archive). A fake sendmail script deposits messages into `INBOX/new/` to simulate delivery. Himalaya auto-saves sent copies to Sent.

No Python, no Docker, no test servers — just himalaya + maildir + bash.

## Tests (26 total)

| File | Tests | Coverage |
|------|-------|----------|
| send.bats | 9 | Delivery, Sent copy, GPG signing, body validation, stdin, file input, HTML |
| list.bats | 5 | Listing, limit, folder filtering, count, empty folder |
| read.bats | 4 | Content display, sender info, cross-folder reads, nonexistent message |
| delete.bats | 4 | Move to Trash, permanent delete, Trash rejection, bulk delete |
| archive.bats | 1 | Move to Archive |
| roundtrip.bats | 3 | Full send→list→read→delete lifecycle, send→archive, message isolation |

## Notes

- Found a pre-existing bug: `read` task exits 0 for nonexistent messages because himalaya's error is swallowed by the sed pipe. Test documents current behavior; fix can be separate.
- Run with: `mise run test-integration`
- Unit tests (`mise run test`) still pass (31/31).