### PR TITLE
Add CC support to send and reply

### DIFF
--- a/.mise/tasks/reply
+++ b/.mise/tasks/reply
@@ -3,6 +3,7 @@
 #USAGE arg "<id>" help="Message ID to reply to"
 #USAGE arg "[body]" help="Reply body (optional, or use -b flag or stdin)"
 #USAGE flag "-b --body <body>" help="Reply body (alternative to positional arg)"
+#USAGE flag "-c --cc <cc>" help="CC recipient (repeatable)" var=#true
 #USAGE flag "-a --attach <attach>" help="File path to attach (repeatable)" var=#true
 #USAGE flag "--allow-short" help="Allow short reply bodies (under 50 chars)"
 #USAGE flag "--html" help="Send reply as HTML (Content-Type: text/html)"
@@ -86,6 +87,12 @@ if [ -z "$REPLY_TO" ]; then
   echo "Error: Cannot determine recipient for reply (empty To: header)."
   echo "This can happen when replying to your own messages."
   exit 1
+fi
+
+# Add CC header if specified
+if [ -n "${usage_cc:-}" ]; then
+  CC_ADDRS=$(echo "$usage_cc" | xargs -n1 printf '%s\n' | paste -sd ',' - | sed 's/,/, /g')
+  HEADERS=$(echo "$HEADERS" | sed "/^Subject:/a\\\nCc: $CC_ADDRS")
 fi
 
 # Build the full message with signed body and optional attachments

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -4,6 +4,7 @@
 #USAGE arg "<subject>" help="Email subject"
 #USAGE arg "[body]" help="Message body (optional, or use -b flag or stdin)"
 #USAGE flag "-b --body <body>" help="Message body (alternative to positional arg)"
+#USAGE flag "-c --cc <cc>" help="CC recipient (repeatable)" var=#true
 #USAGE flag "-a --attach <attach>" help="File path to attach (repeatable)" var=#true
 #USAGE flag "--allow-short" help="Allow short message bodies (under 50 chars)"
 #USAGE flag "--html" help="Send body as HTML (Content-Type: text/html)"
@@ -27,6 +28,11 @@ if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
   echo "HTML email:"
   echo "  emails send admin@ricon.family 'Subject' --html -b /path/to/file.html"
   echo "  cat body.html | emails send admin@ricon.family 'Subject' --html"
+  echo ""
+  echo "Attachments:"
+  echo "CC:"
+  echo "  emails send admin@ricon.family 'Subject' 'body' -c other@ricon.family"
+  echo "  emails send admin@ricon.family 'Subject' 'body' -c one@x.com -c two@x.com"
   echo ""
   echo "Attachments:"
   echo "  emails send admin@ricon.family 'Subject' 'body' -a /path/to/file.pdf"
@@ -92,11 +98,19 @@ if [ -n "${usage_attach:-}" ]; then
   done < <(echo "$usage_attach" | xargs -n1 printf '%s\n')
 fi
 
+# Build CC header
+CC_HEADER=""
+if [ -n "${usage_cc:-}" ]; then
+  CC_ADDRS=$(echo "$usage_cc" | xargs -n1 printf '%s\n' | paste -sd ',' - | sed 's/,/, /g')
+  CC_HEADER="Cc: $CC_ADDRS"
+fi
+
 # Send with GPG signing using MML template.
 himalaya template send -a "$AGENT" << EOF
 From: $FROM
 To: $TO
-Subject: $SUBJECT
+${CC_HEADER:+$CC_HEADER
+}Subject: $SUBJECT
 
 <#multipart type=mixed sign=pgpmime>
 <#part type=$CONTENT_TYPE>
@@ -106,4 +120,8 @@ $ATTACH_MML
 <#/multipart>
 EOF
 
-echo "Sent to $TO"
+if [ -n "${CC_HEADER:-}" ]; then
+  echo "Sent to $TO (cc: $CC_ADDRS)"
+else
+  echo "Sent to $TO"
+fi

--- a/test/integration/send.bats
+++ b/test/integration/send.bats
@@ -88,3 +88,16 @@ HTML
   run cat "$sent_msg"
   [[ "$output" == *"text/html"* ]]
 }
+
+@test "send: cc flag adds Cc header" {
+  emails send test-agent@ricon.family "CC test" \
+    "This message tests that the CC flag adds a proper Cc header to the sent email." \
+    -c alice@example.com -c bob@example.com
+
+  local sent_msg
+  sent_msg=$(find "$MAILDIR_ROOT/Sent" -type f | head -1)
+  run cat "$sent_msg"
+  [[ "$output" == *"Cc:"* ]]
+  [[ "$output" == *"alice@example.com"* ]]
+  [[ "$output" == *"bob@example.com"* ]]
+}


### PR DESCRIPTION
New `-c/--cc` flag (repeatable) on both `send` and `reply`.

```bash
emails send user@x.com 'Subject' 'body' -c alice@x.com -c bob@x.com
emails reply 42 'body' -c alice@x.com
```

Integration test added. All 58 tests pass (31 unit + 27 integration).