### PR TITLE
Add emails compose — TSX-based email authoring

### DIFF
--- a/.mise/tasks/compose
+++ b/.mise/tasks/compose
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#MISE description="Compose an email from a TSX file"
+#USAGE arg "<file>" help="Path to .tsx file"
+#USAGE arg "[args]" var=#true help="Arguments to pass to the TSX file"
+
+set -euo pipefail
+
+FILE="${usage_file:-$1}"
+
+if [ -z "$FILE" ]; then
+  echo "Usage: emails compose <file.tsx> [--arg value ...]" >&2
+  exit 1
+fi
+
+# Resolve relative paths from caller's directory
+if [[ "$FILE" != /* ]]; then
+  FILE="${CALLER_PWD:-$(pwd)}/$FILE"
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: file not found: $FILE" >&2
+  exit 1
+fi
+
+# Build tsconfig override for JSX and import resolution.
+# Points at the emails package src/ for the JSX runtime and components.
+EMAILS_DIR="$MISE_CONFIG_ROOT"
+TSCONFIG=$(mktemp)
+cat > "$TSCONFIG" <<CONF
+{
+  "compilerOptions": {
+    "paths": {
+      "emails/jsx-runtime": ["$EMAILS_DIR/src/jsx-runtime.ts"],
+      "emails/jsx-dev-runtime": ["$EMAILS_DIR/src/jsx-dev-runtime.ts"],
+      "emails": ["$EMAILS_DIR/src/components/index.ts"],
+      "emails/*": ["$EMAILS_DIR/*"]
+    }
+  }
+}
+CONF
+trap 'rm -f "$TSCONFIG"' EXIT
+
+# Parse variadic args for passthrough
+ARGS=()
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    ARGS+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+fi
+
+# Run the TSX file with bun, passing through any extra args.
+# Filter the spurious "directory mismatch" warning from oven-sh/bun#22023.
+bun run --tsconfig-override "$TSCONFIG" "$FILE" ${ARGS[@]+"${ARGS[@]}"} 2> >(grep -v "Internal error: directory mismatch" >&2)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ shiv install KnickKnackLabs/emails
 | `emails status` | Check setup status for an agent |
 | `emails setup` | One-time himalaya configuration |
 | `emails welcome` | Overview and current status |
+| `emails compose` | Render a TSX email program to HTML |
 
 ## HTML Email
 
@@ -42,6 +43,36 @@ cat email.html | emails send user@example.com "Subject" --html
 # Reply with HTML
 emails reply 42 --html -b '<h1>Thanks!</h1><p>Got it.</p>'
 ```
+
+## Compose
+
+`emails compose` runs a `.tsx` file that imports email components and prints the rendered body. The TSX file is a small program: parse flags, fetch data, decide what to show, then return HTML.
+
+```tsx
+/** @jsxImportSource emails */
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import { Heading, Paragraph, Link } from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: { name: { type: "string" } },
+});
+
+console.log(email({
+  body: <>
+    <Heading>Hello {values.name}</Heading>
+    <Paragraph><Link href="https://example.com">Open report</Link></Paragraph>
+  </>,
+}));
+```
+
+```bash
+emails compose ./hello.tsx --name x1f9 \
+  | emails send or@example.com "Hello" --html
+```
+
+Text children are HTML-escaped by default. Use `<Raw>` only for trusted HTML.
 
 ## Setup
 

--- a/examples/alert.tsx
+++ b/examples/alert.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource emails */
+// Alert — something broke, someone needs to know.
+//
+// Usage:
+//   emails compose examples/alert.tsx \
+//     --severity error \
+//     --title "CI failed on shimmer main" \
+//     --detail "GPG key expired for x1f9 — signing step fails" \
+//     --detail "Last successful run: 2026-04-03 08:30 UTC" \
+//     --action "Rotate GPG key: shimmer gpg:rotate x1f9" \
+//     --link "https://github.com/KnickKnackLabs/shimmer/actions/runs/12345"
+
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import {
+  Heading, Paragraph, Bold, Code, Link,
+  Card, Section, List, Item,
+  Table, Row, Cell, HeaderCell,
+  Footer,
+} from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    severity: { type: "string", default: "warning" },
+    title:    { type: "string" },
+    detail:   { type: "string", multiple: true, default: [] },
+    action:   { type: "string", multiple: true, default: [] },
+    link:     { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.title) {
+  console.error("Usage: emails compose alert.tsx --title <message> [--severity error|warning|info] [--detail ...] [--action ...]");
+  process.exit(1);
+}
+
+const variant = (values.severity === "error" ? "error"
+  : values.severity === "info" ? "info"
+  : "warning") as "error" | "warning" | "info";
+
+const emoji = { error: "🔴", warning: "🟡", info: "🔵" }[variant];
+
+const body = (
+  <>
+    <Heading>{emoji} {values.title}</Heading>
+
+    <Card variant={variant} title={`Severity: ${values.severity}`}>
+      {values.detail!.length > 0 ? values.detail![0] : null}
+    </Card>
+
+    {values.detail!.length > 1 && (
+      <Section title="Details">
+        <List>
+          {values.detail!.slice(1).map((d: string) => <Item>{d}</Item>)}
+        </List>
+      </Section>
+    )}
+
+    {values.action!.length > 0 && (
+      <Section title="Suggested actions">
+        <List>
+          {values.action!.map((a: string) => (
+            <Item><Code>{a}</Code></Item>
+          ))}
+        </List>
+      </Section>
+    )}
+
+    {values.link && (
+      <Paragraph>
+        <Link href={values.link}>View details →</Link>
+      </Paragraph>
+    )}
+
+    <Footer>
+      {"Automated alert via "}<Code>emails compose</Code>
+    </Footer>
+  </>
+);
+
+console.log(email({ body }));

--- a/examples/digest.tsx
+++ b/examples/digest.tsx
@@ -1,0 +1,131 @@
+/** @jsxImportSource emails */
+// Digest — pull live data and summarize it.
+//
+// This one's interesting because it fetches data at compose time.
+// The TSX file is a program — it can do anything before rendering.
+//
+// Usage:
+//   emails compose examples/digest.tsx --org KnickKnackLabs --days 7
+
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import {
+  Heading, Paragraph, Bold, Code, Link,
+  Section, Stats, Stat,
+  Table, Row, Cell, HeaderCell,
+  List, Item,
+  Footer, HR,
+} from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    org:  { type: "string", default: "KnickKnackLabs" },
+    days: { type: "string", default: "7" },
+  },
+  strict: true,
+});
+
+const days = parseInt(values.days!, 10);
+const since = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+const until = new Date().toISOString().slice(0, 10);
+
+// --- Fetch data at compose time ---
+
+interface PRData {
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  mergedAt: string;
+  url: string;
+}
+
+let prs: PRData[] = [];
+let fetchError: string | null = null;
+
+try {
+  // Use gh CLI to get recently merged PRs
+  const result = Bun.spawnSync([
+    "gh", "search", "prs",
+    "--owner", values.org!,
+    "--merged-at", `>${since}`,
+    "--sort", "updated",
+    "--limit", "20",
+    "--json", "repository,number,title,author,updatedAt,url",
+  ]);
+
+  if (result.exitCode === 0) {
+    const raw = JSON.parse(result.stdout.toString());
+    prs = raw.map((pr: any) => ({
+      repo: pr.repository.name,
+      number: pr.number,
+      title: pr.title,
+      author: pr.author.login,
+      mergedAt: pr.updatedAt.slice(0, 10),
+      url: pr.url,
+    }));
+  } else {
+    fetchError = result.stderr.toString().trim();
+  }
+} catch (e: any) {
+  fetchError = e.message;
+}
+
+// --- Aggregate ---
+
+const repoSet = new Set(prs.map(pr => pr.repo));
+const authorSet = new Set(prs.map(pr => pr.author));
+const byRepo = new Map<string, PRData[]>();
+for (const pr of prs) {
+  if (!byRepo.has(pr.repo)) byRepo.set(pr.repo, []);
+  byRepo.get(pr.repo)!.push(pr);
+}
+
+// --- Render ---
+
+const body = (
+  <>
+    <Heading>{values.org} — weekly digest</Heading>
+    <Paragraph style="color:#64748b;font-size:13px;">
+      {since} → {until} ({days} days)
+    </Paragraph>
+
+    {fetchError && (
+      <Paragraph style="color:#b91c1c;font-size:13px;">
+        {"⚠ Could not fetch PR data: "}{fetchError}
+      </Paragraph>
+    )}
+
+    <Stats>
+      <Stat>{prs.length} PRs merged</Stat>
+      <Stat>{repoSet.size} repos active</Stat>
+      <Stat>{authorSet.size} contributors</Stat>
+    </Stats>
+
+    {[...byRepo.entries()].map(([repo, repoPrs]) => (
+      <Section title={repo}>
+        <Table>
+          <Row>
+            <HeaderCell>PR</HeaderCell>
+            <HeaderCell>Title</HeaderCell>
+            <HeaderCell>Author</HeaderCell>
+          </Row>
+          {repoPrs.map(pr => (
+            <Row>
+              <Cell><Link href={pr.url}>#{pr.number}</Link></Cell>
+              <Cell>{pr.title}</Cell>
+              <Cell>{pr.author}</Cell>
+            </Row>
+          ))}
+        </Table>
+      </Section>
+    ))}
+
+    <Footer>
+      {"Generated "}{until}{" via "}<Code>emails compose</Code>
+    </Footer>
+  </>
+);
+
+console.log(email({ body }));

--- a/examples/review-request.tsx
+++ b/examples/review-request.tsx
@@ -1,0 +1,81 @@
+/** @jsxImportSource emails */
+// Review request — ask a colleague to review a PR.
+//
+// Usage:
+//   emails compose examples/review-request.tsx \
+//     --repo KnickKnackLabs/swallow \
+//     --pr 1 \
+//     --title "Initial implementation" \
+//     --reviewer brownie \
+//     --summary "92 tests, JSON + lines strategies, jq-based merge engine" \
+//     --concern "The jq overlap detection uses nested reduce — might be slow on large inputs"
+
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import {
+  Heading, Paragraph, Bold, Code, Link,
+  Card, Section, List, Item,
+  Footer,
+} from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    repo:     { type: "string" },
+    pr:       { type: "string" },
+    title:    { type: "string" },
+    reviewer: { type: "string" },
+    summary:  { type: "string" },
+    concern:  { type: "string", multiple: true, default: [] },
+    context:  { type: "string", multiple: true, default: [] },
+  },
+  strict: true,
+});
+
+if (!values.repo || !values.pr || !values.reviewer) {
+  console.error("Usage: emails compose review-request.tsx --repo <owner/repo> --pr <number> --reviewer <name>");
+  process.exit(1);
+}
+
+const prUrl = `https://github.com/${values.repo}/pull/${values.pr}`;
+
+const body = (
+  <>
+    <Heading level={1}>Review request</Heading>
+
+    <Card variant="info" title={values.repo}>
+      <Link href={prUrl}>#{values.pr}</Link>
+      {values.title ? ` — ${values.title}` : ""}
+    </Card>
+
+    <Paragraph>
+      {"Hey "}<Bold>{values.reviewer}</Bold>{" — would you take a look at this?"}
+    </Paragraph>
+
+    {values.summary && (
+      <Section title="What changed">
+        <Paragraph>{values.summary}</Paragraph>
+      </Section>
+    )}
+
+    {values.concern!.length > 0 && (
+      <Section title="Things I'd appreciate eyes on">
+        <List>
+          {values.concern!.map((c: string) => <Item>{c}</Item>)}
+        </List>
+      </Section>
+    )}
+
+    {values.context!.length > 0 && (
+      <Section title="Context">
+        {values.context!.map((c: string) => <Paragraph>{c}</Paragraph>)}
+      </Section>
+    )}
+
+    <Footer>
+      <Link href={prUrl}>View on GitHub</Link>
+    </Footer>
+  </>
+);
+
+console.log(email({ body }));

--- a/examples/session-report.tsx
+++ b/examples/session-report.tsx
@@ -1,0 +1,81 @@
+/** @jsxImportSource emails */
+// Session report — the end-of-session email to Or.
+//
+// Usage:
+//   emails compose examples/session-report.tsx \
+//     --agent x1f9 \
+//     --shipped "swallow: 92 tests, README, shiv registered" \
+//     --shipped "fold: creating-a-codebase hub note" \
+//     --next "emails compose pipeline" \
+//     --next "or#76 filename obfuscation"
+
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import {
+  Heading, Paragraph, Bold, Code, Link,
+  Card, Section, Stats, Stat, List, Item,
+  Footer,
+} from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    agent:   { type: "string" },
+    shipped: { type: "string", multiple: true, default: [] },
+    next:    { type: "string", multiple: true, default: [] },
+    note:    { type: "string", multiple: true, default: [] },
+  },
+  strict: true,
+});
+
+if (!values.agent) {
+  console.error("Usage: emails compose session-report.tsx --agent <name> [--shipped ...] [--next ...]");
+  process.exit(1);
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const day = new Date().toLocaleDateString("en-US", { weekday: "long" });
+
+const body = (
+  <>
+    <Heading>{values.agent} — session report</Heading>
+    <Paragraph style="color:#64748b;font-size:13px;">
+      {today} · {day}
+    </Paragraph>
+
+    {values.shipped!.length > 0 && (
+      <Section title="Shipped">
+        {values.shipped!.map((item: string) => {
+          const [title, ...rest] = item.split(": ");
+          return (
+            <Card variant="success" title={title}>
+              {rest.join(": ") || null}
+            </Card>
+          );
+        })}
+      </Section>
+    )}
+
+    {values.next!.length > 0 && (
+      <Section title="Next session">
+        <List>
+          {values.next!.map((item: string) => <Item>{item}</Item>)}
+        </List>
+      </Section>
+    )}
+
+    {values.note!.length > 0 && (
+      <Section title="Notes">
+        {values.note!.map((item: string) => (
+          <Paragraph>{item}</Paragraph>
+        ))}
+      </Section>
+    )}
+
+    <Footer>
+      {"Composed with "}<Code>emails compose</Code>
+    </Footer>
+  </>
+);
+
+console.log(email({ body }));

--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,4 @@ task_output = "interleave"
 [tools]
 jq = "latest"
 bats = "1.13.0"
+bun = "1"

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -1,0 +1,312 @@
+/** @jsxImportSource emails */
+import { expect, test, describe } from "bun:test";
+import {
+  Heading, Paragraph, Code, Bold, Link, HR, LineBreak, Spacer,
+  Card,
+  Table, Row, Cell, HeaderCell,
+  Stat, Stats,
+  Section,
+  List, Item,
+  Footer,
+  Raw,
+} from "./components";
+
+// --- Text elements ---
+
+describe("Heading", () => {
+  test("renders h1 by default", () => {
+    const html = <Heading>Title</Heading>;
+    expect(html).toContain("<h1");
+    expect(html).toContain("Title");
+    expect(html).toContain("</h1>");
+  });
+
+  test("renders h2 with level prop", () => {
+    const html = <Heading level={2}>Subtitle</Heading>;
+    expect(html).toContain("<h2");
+    expect(html).toContain("Subtitle");
+  });
+
+  test("renders h3 with level prop", () => {
+    const html = <Heading level={3}>Small</Heading>;
+    expect(html).toContain("<h3");
+  });
+
+  test("includes inline styles", () => {
+    const html = <Heading>Title</Heading>;
+    expect(html).toContain("style=");
+    expect(html).toContain("font-size");
+  });
+});
+
+describe("Paragraph", () => {
+  test("wraps text in p tag", () => {
+    const html = <Paragraph>Hello world</Paragraph>;
+    expect(html).toContain("<p");
+    expect(html).toContain("Hello world");
+    expect(html).toContain("</p>");
+  });
+
+  test("includes default styles", () => {
+    const html = <Paragraph>Text</Paragraph>;
+    expect(html).toContain("font-size:14px");
+  });
+
+  test("accepts custom style", () => {
+    const html = <Paragraph style="color:red;">Red text</Paragraph>;
+    expect(html).toContain("color:red;");
+  });
+});
+
+describe("Code", () => {
+  test("renders inline code with background", () => {
+    const html = <Code>foo()</Code>;
+    expect(html).toContain("<code");
+    expect(html).toContain("foo()");
+    expect(html).toContain("background");
+  });
+});
+
+describe("Bold", () => {
+  test("wraps in strong tag", () => {
+    const html = <Bold>important</Bold>;
+    expect(html).toBe("<strong>important</strong>");
+  });
+});
+
+describe("Link", () => {
+  test("renders anchor tag", () => {
+    const html = <Link href="https://example.com">click</Link>;
+    expect(html).toContain('<a href="https://example.com"');
+    expect(html).toContain("click");
+    expect(html).toContain("</a>");
+  });
+
+  test("includes color style", () => {
+    const html = <Link href="https://example.com">click</Link>;
+    expect(html).toContain("color:");
+  });
+});
+
+describe("HR", () => {
+  test("renders horizontal rule", () => {
+    const html = <HR />;
+    expect(html).toContain("<hr");
+    expect(html).toContain("border");
+  });
+});
+
+describe("LineBreak", () => {
+  test("renders br tag", () => {
+    const html = <LineBreak />;
+    expect(html).toContain("<br");
+  });
+});
+
+describe("Spacer", () => {
+  test("renders div with default height", () => {
+    const html = <Spacer />;
+    expect(html).toContain("height:16px");
+  });
+
+  test("accepts custom height", () => {
+    const html = <Spacer height={32} />;
+    expect(html).toContain("height:32px");
+  });
+});
+
+// --- Card ---
+
+describe("Card", () => {
+  test("renders with default info variant", () => {
+    const html = <Card>Content</Card>;
+    expect(html).toContain("Content");
+    expect(html).toContain("border-left");
+  });
+
+  test("renders success variant", () => {
+    const html = <Card variant="success" title="Shipped">Details</Card>;
+    expect(html).toContain("#f0fdf4"); // success bg
+    expect(html).toContain("#22c55e"); // success border
+    expect(html).toContain("Shipped");
+    expect(html).toContain("Details");
+  });
+
+  test("renders warning variant", () => {
+    const html = <Card variant="warning">Watch out</Card>;
+    expect(html).toContain("#fffbeb"); // warning bg
+  });
+
+  test("renders error variant", () => {
+    const html = <Card variant="error">Failed</Card>;
+    expect(html).toContain("#fef2f2"); // error bg
+  });
+
+  test("title is optional", () => {
+    const html = <Card variant="info">Just body</Card>;
+    expect(html).toContain("Just body");
+    expect(html).not.toContain("<strong");
+  });
+
+  test("body is optional", () => {
+    const html = <Card variant="success" title="Title only" />;
+    expect(html).toContain("Title only");
+  });
+});
+
+// --- Table ---
+
+describe("Table", () => {
+  test("renders table with border-collapse", () => {
+    const html = (
+      <Table>
+        <Row>
+          <Cell>A</Cell>
+          <Cell>B</Cell>
+        </Row>
+      </Table>
+    );
+    expect(html).toContain("<table");
+    expect(html).toContain("border-collapse");
+    expect(html).toContain("<tr>");
+    expect(html).toContain("<td");
+    expect(html).toContain("A");
+    expect(html).toContain("B");
+  });
+
+  test("header cells have background", () => {
+    const html = (
+      <Row>
+        <HeaderCell>Name</HeaderCell>
+      </Row>
+    );
+    expect(html).toContain("<th");
+    expect(html).toContain("background");
+    expect(html).toContain("Name");
+  });
+});
+
+// --- Stats ---
+
+describe("Stats", () => {
+  test("renders stat pills", () => {
+    const html = (
+      <Stats>
+        <Stat>7 PRs</Stat>
+        <Stat>3 repos</Stat>
+      </Stats>
+    );
+    expect(html).toContain("7 PRs");
+    expect(html).toContain("3 repos");
+    expect(html).toContain("border-radius");
+    expect(html).toContain("inline-block");
+  });
+});
+
+// --- Layout ---
+
+describe("Section", () => {
+  test("renders heading and children", () => {
+    const html = (
+      <Section title="Overview">
+        <Paragraph>Content here</Paragraph>
+      </Section>
+    );
+    expect(html).toContain("Overview");
+    expect(html).toContain("Content here");
+    expect(html).toContain("<h2");
+  });
+});
+
+// --- List ---
+
+describe("List", () => {
+  test("renders unordered list", () => {
+    const html = (
+      <List>
+        <Item>First</Item>
+        <Item>Second</Item>
+      </List>
+    );
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li");
+    expect(html).toContain("First");
+    expect(html).toContain("Second");
+  });
+
+  test("renders ordered list", () => {
+    const html = (
+      <List ordered>
+        <Item>One</Item>
+        <Item>Two</Item>
+      </List>
+    );
+    expect(html).toContain("<ol");
+  });
+});
+
+// --- Footer ---
+
+describe("Footer", () => {
+  test("renders footer with border and muted text", () => {
+    const html = <Footer>Built with love</Footer>;
+    expect(html).toContain("Built with love");
+    expect(html).toContain("border-top");
+    expect(html).toContain("color:");
+  });
+});
+
+// --- Raw ---
+
+describe("Raw", () => {
+  test("passes through HTML unchanged", () => {
+    const html = <Raw>{"<div class='custom'>hello</div>"}</Raw>;
+    expect(html).toBe("<div class='custom'>hello</div>");
+  });
+});
+
+// --- Composition ---
+
+describe("Composition", () => {
+  test("components nest correctly", () => {
+    const html = (
+      <Section title="Report">
+        <Card variant="success" title="Shipped">
+          <Bold>emails</Bold>{" — extraction complete"}
+        </Card>
+        <Table>
+          <Row>
+            <HeaderCell>Repo</HeaderCell>
+            <HeaderCell>PR</HeaderCell>
+          </Row>
+          <Row>
+            <Cell><Link href="https://github.com/KnickKnackLabs/emails/pull/1">#1</Link></Cell>
+            <Cell>Integration tests</Cell>
+          </Row>
+        </Table>
+        <Stats>
+          <Stat>7 PRs merged</Stat>
+          <Stat>6 repos touched</Stat>
+        </Stats>
+      </Section>
+    );
+    expect(html).toContain("<h2");
+    expect(html).toContain("Report");
+    expect(html).toContain("#f0fdf4"); // success card
+    expect(html).toContain("<strong>emails</strong>");
+    expect(html).toContain("<table");
+    expect(html).toContain("#1");
+    expect(html).toContain("7 PRs merged");
+  });
+
+  test("fragment composes multiple elements", () => {
+    const html = (
+      <>
+        <Heading>Title</Heading>
+        <Paragraph>Body</Paragraph>
+      </>
+    );
+    expect(html).toContain("<h1");
+    expect(html).toContain("<p");
+  });
+});

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -39,6 +39,11 @@ describe("Heading", () => {
     expectHtml(html).toContain("style=");
     expectHtml(html).toContain("font-size");
   });
+
+  test("rejects invalid level values at runtime", () => {
+    expect(() => <Heading level={'1 onclick="alert(1)' as any}>Title</Heading>)
+      .toThrow("Heading level must be 1, 2, or 3");
+  });
 });
 
 describe("Paragraph", () => {
@@ -131,6 +136,13 @@ describe("Spacer", () => {
   test("accepts custom height", () => {
     const html = <Spacer height={32} />;
     expectHtml(html).toContain("height:32px");
+  });
+
+  test("rejects invalid height values at runtime", () => {
+    expect(() => <Spacer height={'1" onclick="alert(1)' as any} />)
+      .toThrow("Spacer height must be a finite non-negative number");
+    expect(() => <Spacer height={-1} />)
+      .toThrow("Spacer height must be a finite non-negative number");
   });
 });
 

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -11,107 +11,126 @@ import {
   Raw,
 } from "./components";
 
+const expectHtml = (value: any) => expect(String(value));
+
 // --- Text elements ---
 
 describe("Heading", () => {
   test("renders h1 by default", () => {
     const html = <Heading>Title</Heading>;
-    expect(html).toContain("<h1");
-    expect(html).toContain("Title");
-    expect(html).toContain("</h1>");
+    expectHtml(html).toContain("<h1");
+    expectHtml(html).toContain("Title");
+    expectHtml(html).toContain("</h1>");
   });
 
   test("renders h2 with level prop", () => {
     const html = <Heading level={2}>Subtitle</Heading>;
-    expect(html).toContain("<h2");
-    expect(html).toContain("Subtitle");
+    expectHtml(html).toContain("<h2");
+    expectHtml(html).toContain("Subtitle");
   });
 
   test("renders h3 with level prop", () => {
     const html = <Heading level={3}>Small</Heading>;
-    expect(html).toContain("<h3");
+    expectHtml(html).toContain("<h3");
   });
 
   test("includes inline styles", () => {
     const html = <Heading>Title</Heading>;
-    expect(html).toContain("style=");
-    expect(html).toContain("font-size");
+    expectHtml(html).toContain("style=");
+    expectHtml(html).toContain("font-size");
   });
 });
 
 describe("Paragraph", () => {
   test("wraps text in p tag", () => {
     const html = <Paragraph>Hello world</Paragraph>;
-    expect(html).toContain("<p");
-    expect(html).toContain("Hello world");
-    expect(html).toContain("</p>");
+    expectHtml(html).toContain("<p");
+    expectHtml(html).toContain("Hello world");
+    expectHtml(html).toContain("</p>");
   });
 
   test("includes default styles", () => {
     const html = <Paragraph>Text</Paragraph>;
-    expect(html).toContain("font-size:14px");
+    expectHtml(html).toContain("font-size:14px");
   });
 
   test("accepts custom style", () => {
     const html = <Paragraph style="color:red;">Red text</Paragraph>;
-    expect(html).toContain("color:red;");
+    expectHtml(html).toContain("color:red;");
+  });
+
+  test("escapes text children by default", () => {
+    const html = <Paragraph>{'<script>alert("x")</script> & more'}</Paragraph>;
+    expectHtml(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; more");
+    expectHtml(html).not.toContain("<script>");
   });
 });
 
 describe("Code", () => {
   test("renders inline code with background", () => {
     const html = <Code>foo()</Code>;
-    expect(html).toContain("<code");
-    expect(html).toContain("foo()");
-    expect(html).toContain("background");
+    expectHtml(html).toContain("<code");
+    expectHtml(html).toContain("foo()");
+    expectHtml(html).toContain("background");
   });
 });
 
 describe("Bold", () => {
   test("wraps in strong tag", () => {
     const html = <Bold>important</Bold>;
-    expect(html).toBe("<strong>important</strong>");
+    expectHtml(html).toBe("<strong>important</strong>");
   });
 });
 
 describe("Link", () => {
   test("renders anchor tag", () => {
     const html = <Link href="https://example.com">click</Link>;
-    expect(html).toContain('<a href="https://example.com"');
-    expect(html).toContain("click");
-    expect(html).toContain("</a>");
+    expectHtml(html).toContain('<a href="https://example.com"');
+    expectHtml(html).toContain("click");
+    expectHtml(html).toContain("</a>");
   });
 
   test("includes color style", () => {
     const html = <Link href="https://example.com">click</Link>;
-    expect(html).toContain("color:");
+    expectHtml(html).toContain("color:");
+  });
+
+  test("escapes href attributes", () => {
+    const html = <Link href={'https://example.com/?q="quoted"&ok=1'}>click</Link>;
+    expectHtml(html).toContain('href="https://example.com/?q=&quot;quoted&quot;&amp;ok=1"');
+  });
+
+  test("rejects unsafe protocols", () => {
+    const html = <Link href="javascript:alert(1)">click</Link>;
+    expectHtml(html).toContain('href="#"');
+    expectHtml(html).not.toContain("javascript:");
   });
 });
 
 describe("HR", () => {
   test("renders horizontal rule", () => {
     const html = <HR />;
-    expect(html).toContain("<hr");
-    expect(html).toContain("border");
+    expectHtml(html).toContain("<hr");
+    expectHtml(html).toContain("border");
   });
 });
 
 describe("LineBreak", () => {
   test("renders br tag", () => {
     const html = <LineBreak />;
-    expect(html).toContain("<br");
+    expectHtml(html).toContain("<br");
   });
 });
 
 describe("Spacer", () => {
   test("renders div with default height", () => {
     const html = <Spacer />;
-    expect(html).toContain("height:16px");
+    expectHtml(html).toContain("height:16px");
   });
 
   test("accepts custom height", () => {
     const html = <Spacer height={32} />;
-    expect(html).toContain("height:32px");
+    expectHtml(html).toContain("height:32px");
   });
 });
 
@@ -120,37 +139,37 @@ describe("Spacer", () => {
 describe("Card", () => {
   test("renders with default info variant", () => {
     const html = <Card>Content</Card>;
-    expect(html).toContain("Content");
-    expect(html).toContain("border-left");
+    expectHtml(html).toContain("Content");
+    expectHtml(html).toContain("border-left");
   });
 
   test("renders success variant", () => {
     const html = <Card variant="success" title="Shipped">Details</Card>;
-    expect(html).toContain("#f0fdf4"); // success bg
-    expect(html).toContain("#22c55e"); // success border
-    expect(html).toContain("Shipped");
-    expect(html).toContain("Details");
+    expectHtml(html).toContain("#f0fdf4"); // success bg
+    expectHtml(html).toContain("#22c55e"); // success border
+    expectHtml(html).toContain("Shipped");
+    expectHtml(html).toContain("Details");
   });
 
   test("renders warning variant", () => {
     const html = <Card variant="warning">Watch out</Card>;
-    expect(html).toContain("#fffbeb"); // warning bg
+    expectHtml(html).toContain("#fffbeb"); // warning bg
   });
 
   test("renders error variant", () => {
     const html = <Card variant="error">Failed</Card>;
-    expect(html).toContain("#fef2f2"); // error bg
+    expectHtml(html).toContain("#fef2f2"); // error bg
   });
 
   test("title is optional", () => {
     const html = <Card variant="info">Just body</Card>;
-    expect(html).toContain("Just body");
-    expect(html).not.toContain("<strong");
+    expectHtml(html).toContain("Just body");
+    expectHtml(html).not.toContain("<strong");
   });
 
   test("body is optional", () => {
     const html = <Card variant="success" title="Title only" />;
-    expect(html).toContain("Title only");
+    expectHtml(html).toContain("Title only");
   });
 });
 
@@ -166,12 +185,12 @@ describe("Table", () => {
         </Row>
       </Table>
     );
-    expect(html).toContain("<table");
-    expect(html).toContain("border-collapse");
-    expect(html).toContain("<tr>");
-    expect(html).toContain("<td");
-    expect(html).toContain("A");
-    expect(html).toContain("B");
+    expectHtml(html).toContain("<table");
+    expectHtml(html).toContain("border-collapse");
+    expectHtml(html).toContain("<tr>");
+    expectHtml(html).toContain("<td");
+    expectHtml(html).toContain("A");
+    expectHtml(html).toContain("B");
   });
 
   test("header cells have background", () => {
@@ -180,9 +199,9 @@ describe("Table", () => {
         <HeaderCell>Name</HeaderCell>
       </Row>
     );
-    expect(html).toContain("<th");
-    expect(html).toContain("background");
-    expect(html).toContain("Name");
+    expectHtml(html).toContain("<th");
+    expectHtml(html).toContain("background");
+    expectHtml(html).toContain("Name");
   });
 });
 
@@ -196,10 +215,10 @@ describe("Stats", () => {
         <Stat>3 repos</Stat>
       </Stats>
     );
-    expect(html).toContain("7 PRs");
-    expect(html).toContain("3 repos");
-    expect(html).toContain("border-radius");
-    expect(html).toContain("inline-block");
+    expectHtml(html).toContain("7 PRs");
+    expectHtml(html).toContain("3 repos");
+    expectHtml(html).toContain("border-radius");
+    expectHtml(html).toContain("inline-block");
   });
 });
 
@@ -212,9 +231,9 @@ describe("Section", () => {
         <Paragraph>Content here</Paragraph>
       </Section>
     );
-    expect(html).toContain("Overview");
-    expect(html).toContain("Content here");
-    expect(html).toContain("<h2");
+    expectHtml(html).toContain("Overview");
+    expectHtml(html).toContain("Content here");
+    expectHtml(html).toContain("<h2");
   });
 });
 
@@ -228,10 +247,10 @@ describe("List", () => {
         <Item>Second</Item>
       </List>
     );
-    expect(html).toContain("<ul");
-    expect(html).toContain("<li");
-    expect(html).toContain("First");
-    expect(html).toContain("Second");
+    expectHtml(html).toContain("<ul");
+    expectHtml(html).toContain("<li");
+    expectHtml(html).toContain("First");
+    expectHtml(html).toContain("Second");
   });
 
   test("renders ordered list", () => {
@@ -241,7 +260,7 @@ describe("List", () => {
         <Item>Two</Item>
       </List>
     );
-    expect(html).toContain("<ol");
+    expectHtml(html).toContain("<ol");
   });
 });
 
@@ -250,9 +269,9 @@ describe("List", () => {
 describe("Footer", () => {
   test("renders footer with border and muted text", () => {
     const html = <Footer>Built with love</Footer>;
-    expect(html).toContain("Built with love");
-    expect(html).toContain("border-top");
-    expect(html).toContain("color:");
+    expectHtml(html).toContain("Built with love");
+    expectHtml(html).toContain("border-top");
+    expectHtml(html).toContain("color:");
   });
 });
 
@@ -261,7 +280,13 @@ describe("Footer", () => {
 describe("Raw", () => {
   test("passes through HTML unchanged", () => {
     const html = <Raw>{"<div class='custom'>hello</div>"}</Raw>;
-    expect(html).toBe("<div class='custom'>hello</div>");
+    expectHtml(html).toBe("<div class='custom'>hello</div>");
+  });
+
+  test("keeps nested component output safe", () => {
+    const html = <Paragraph><Raw>{"<em>raw</em>"}</Raw>{" & escaped"}</Paragraph>;
+    expectHtml(html).toContain("<em>raw</em>");
+    expectHtml(html).toContain(" &amp; escaped");
   });
 });
 
@@ -290,13 +315,13 @@ describe("Composition", () => {
         </Stats>
       </Section>
     );
-    expect(html).toContain("<h2");
-    expect(html).toContain("Report");
-    expect(html).toContain("#f0fdf4"); // success card
-    expect(html).toContain("<strong>emails</strong>");
-    expect(html).toContain("<table");
-    expect(html).toContain("#1");
-    expect(html).toContain("7 PRs merged");
+    expectHtml(html).toContain("<h2");
+    expectHtml(html).toContain("Report");
+    expectHtml(html).toContain("#f0fdf4"); // success card
+    expectHtml(html).toContain("<strong>emails</strong>");
+    expectHtml(html).toContain("<table");
+    expectHtml(html).toContain("#1");
+    expectHtml(html).toContain("7 PRs merged");
   });
 
   test("fragment composes multiple elements", () => {
@@ -306,7 +331,7 @@ describe("Composition", () => {
         <Paragraph>Body</Paragraph>
       </>
     );
-    expect(html).toContain("<h1");
-    expect(html).toContain("<p");
+    expectHtml(html).toContain("<h1");
+    expectHtml(html).toContain("<p");
   });
 });

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -290,6 +290,20 @@ describe("Raw", () => {
   });
 });
 
+// --- Runtime safety ---
+
+describe("Custom components", () => {
+  test("escape plain string returns by default", () => {
+    function UserText({ value }: { value: string }) {
+      return value;
+    }
+
+    const html = <Paragraph><UserText value={'<script>alert("x")</script> & ok'} /></Paragraph>;
+    expectHtml(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; ok");
+    expectHtml(html).not.toContain("<script>");
+  });
+});
+
 // --- Composition ---
 
 describe("Composition", () => {

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,0 +1,18 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+type CardVariant = "success" | "warning" | "info" | "error";
+
+const variantStyles: Record<CardVariant, { bg: string; border: string; titleColor: string }> = {
+  success: { bg: "#f0fdf4", border: "#22c55e", titleColor: "#15803d" },
+  warning: { bg: "#fffbeb", border: "#f59e0b", titleColor: "#b45309" },
+  info:    { bg: "#eff6ff", border: "#3b82f6", titleColor: "#1d4ed8" },
+  error:   { bg: "#fef2f2", border: "#ef4444", titleColor: "#b91c1c" },
+};
+
+export function Card({ variant = "info", title, children }: { variant?: CardVariant; title?: string; children?: any }) {
+  const v = variantStyles[variant];
+  return `<div style="background:${v.bg};border-left:3px solid ${v.border};padding:12px 16px;margin:12px 0;">
+${title ? `<strong style="color:${v.titleColor};">${title}</strong>\n` : ""}${flatten(children) ? `<p style="margin:8px 0 0 0;font-size:14px;">${flatten(children)}</p>` : ""}
+</div>\n`;
+}

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -12,7 +12,8 @@ const variantStyles: Record<CardVariant, { bg: string; border: string; titleColo
 
 export function Card({ variant = "info", title, children }: { variant?: CardVariant; title?: string; children?: any }) {
   const v = variantStyles[variant];
+  const body = flatten(children);
   return `<div style="background:${v.bg};border-left:3px solid ${v.border};padding:12px 16px;margin:12px 0;">
-${title ? `<strong style="color:${v.titleColor};">${title}</strong>\n` : ""}${flatten(children) ? `<p style="margin:8px 0 0 0;font-size:14px;">${flatten(children)}</p>` : ""}
+${title ? `<strong style="color:${v.titleColor};">${flatten(title)}</strong>\n` : ""}${body ? `<p style="margin:8px 0 0 0;font-size:14px;">${body}</p>` : ""}
 </div>\n`;
 }

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 type CardVariant = "success" | "warning" | "info" | "error";
 
@@ -13,7 +13,7 @@ const variantStyles: Record<CardVariant, { bg: string; border: string; titleColo
 export function Card({ variant = "info", title, children }: { variant?: CardVariant; title?: string; children?: any }) {
   const v = variantStyles[variant];
   const body = flatten(children);
-  return `<div style="background:${v.bg};border-left:3px solid ${v.border};padding:12px 16px;margin:12px 0;">
+  return safeHtml(`<div style="background:${v.bg};border-left:3px solid ${v.border};padding:12px 16px;margin:12px 0;">
 ${title ? `<strong style="color:${v.titleColor};">${flatten(title)}</strong>\n` : ""}${body ? `<p style="margin:8px 0 0 0;font-size:14px;">${body}</p>` : ""}
-</div>\n`;
+</div>\n`);
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 export function Footer({ children }: { children?: any }) {
-  return `<div style="margin-top:32px;padding-top:12px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;">${flatten(children)}</div>\n`;
+  return safeHtml(`<div style="margin-top:32px;padding-top:12px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;">${flatten(children)}</div>\n`);
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,6 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Footer({ children }: { children?: any }) {
+  return `<div style="margin-top:32px;padding-top:12px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;">${flatten(children)}</div>\n`;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,8 @@
+export { Heading, Paragraph, Code, Bold, Link, HR, LineBreak, Spacer } from "./text";
+export { Card } from "./card";
+export { Table, Row, Cell, HeaderCell } from "./table";
+export { Stat, Stats } from "./stats";
+export { Section } from "./layout";
+export { List, Item } from "./list";
+export { Footer } from "./footer";
+export { Raw } from "./raw";

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,0 +1,6 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Section({ title, children }: { title: string; children?: any }) {
+  return `<h2 style="font-size:16px;color:#555;margin:24px 0 8px 0;">${title}</h2>\n${flatten(children)}`;
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 export function Section({ title, children }: { title: string; children?: any }) {
-  return `<h2 style="font-size:16px;color:#555;margin:24px 0 8px 0;">${flatten(title)}</h2>\n${flatten(children)}`;
+  return safeHtml(`<h2 style="font-size:16px;color:#555;margin:24px 0 8px 0;">${flatten(title)}</h2>\n${flatten(children)}`);
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -2,5 +2,5 @@
 import { flatten } from "../jsx-runtime";
 
 export function Section({ title, children }: { title: string; children?: any }) {
-  return `<h2 style="font-size:16px;color:#555;margin:24px 0 8px 0;">${title}</h2>\n${flatten(children)}`;
+  return `<h2 style="font-size:16px;color:#555;margin:24px 0 8px 0;">${flatten(title)}</h2>\n${flatten(children)}`;
 }

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,0 +1,11 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function List({ ordered, children }: { ordered?: boolean; children?: any }) {
+  const tag = ordered ? "ol" : "ul";
+  return `<${tag} style="margin:8px 0;padding-left:24px;font-size:14px;">\n${flatten(children)}</${tag}>\n`;
+}
+
+export function Item({ children }: { children?: any }) {
+  return `<li style="margin:4px 0;">${flatten(children)}</li>\n`;
+}

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 export function List({ ordered, children }: { ordered?: boolean; children?: any }) {
   const tag = ordered ? "ol" : "ul";
-  return `<${tag} style="margin:8px 0;padding-left:24px;font-size:14px;">\n${flatten(children)}</${tag}>\n`;
+  return safeHtml(`<${tag} style="margin:8px 0;padding-left:24px;font-size:14px;">\n${flatten(children)}</${tag}>\n`);
 }
 
 export function Item({ children }: { children?: any }) {
-  return `<li style="margin:4px 0;">${flatten(children)}</li>\n`;
+  return safeHtml(`<li style="margin:4px 0;">${flatten(children)}</li>\n`);
 }

--- a/src/components/raw.tsx
+++ b/src/components/raw.tsx
@@ -1,0 +1,6 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Raw({ children }: { children?: any }) {
+  return flatten(children);
+}

--- a/src/components/raw.tsx
+++ b/src/components/raw.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource emails */
-import { flattenRaw } from "../jsx-runtime";
+import { flattenRaw, safeHtml } from "../jsx-runtime";
 
 export function Raw({ children }: { children?: any }) {
-  return flattenRaw(children);
+  return safeHtml(flattenRaw(children));
 }

--- a/src/components/raw.tsx
+++ b/src/components/raw.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flattenRaw } from "../jsx-runtime";
 
 export function Raw({ children }: { children?: any }) {
-  return flatten(children);
+  return flattenRaw(children);
 }

--- a/src/components/stats.tsx
+++ b/src/components/stats.tsx
@@ -1,0 +1,10 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Stat({ children }: { children?: any }) {
+  return `<span style="display:inline-block;background:#f1f5f9;border-radius:4px;padding:4px 10px;margin:2px 4px;font-size:13px;">${flatten(children)}</span>`;
+}
+
+export function Stats({ children }: { children?: any }) {
+  return `<p style="margin:8px 0;">${flatten(children)}</p>\n`;
+}

--- a/src/components/stats.tsx
+++ b/src/components/stats.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 export function Stat({ children }: { children?: any }) {
-  return `<span style="display:inline-block;background:#f1f5f9;border-radius:4px;padding:4px 10px;margin:2px 4px;font-size:13px;">${flatten(children)}</span>`;
+  return safeHtml(`<span style="display:inline-block;background:#f1f5f9;border-radius:4px;padding:4px 10px;margin:2px 4px;font-size:13px;">${flatten(children)}</span>`);
 }
 
 export function Stats({ children }: { children?: any }) {
-  return `<p style="margin:8px 0;">${flatten(children)}</p>\n`;
+  return safeHtml(`<p style="margin:8px 0;">${flatten(children)}</p>\n`);
 }

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,0 +1,19 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Table({ children }: { children?: any }) {
+  return `<table style="border-collapse:collapse;width:100%;margin:12px 0;">
+${flatten(children)}</table>\n`;
+}
+
+export function Row({ children }: { children?: any }) {
+  return `<tr>${flatten(children)}</tr>\n`;
+}
+
+export function HeaderCell({ children }: { children?: any }) {
+  return `<th style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;background:#f8fafc;font-weight:600;">${flatten(children)}</th>`;
+}
+
+export function Cell({ children }: { children?: any }) {
+  return `<td style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;">${flatten(children)}</td>`;
+}

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,19 +1,19 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { flatten, safeHtml } from "../jsx-runtime";
 
 export function Table({ children }: { children?: any }) {
-  return `<table style="border-collapse:collapse;width:100%;margin:12px 0;">
-${flatten(children)}</table>\n`;
+  return safeHtml(`<table style="border-collapse:collapse;width:100%;margin:12px 0;">
+${flatten(children)}</table>\n`);
 }
 
 export function Row({ children }: { children?: any }) {
-  return `<tr>${flatten(children)}</tr>\n`;
+  return safeHtml(`<tr>${flatten(children)}</tr>\n`);
 }
 
 export function HeaderCell({ children }: { children?: any }) {
-  return `<th style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;background:#f8fafc;font-weight:600;">${flatten(children)}</th>`;
+  return safeHtml(`<th style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;background:#f8fafc;font-weight:600;">${flatten(children)}</th>`);
 }
 
 export function Cell({ children }: { children?: any }) {
-  return `<td style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;">${flatten(children)}</td>`;
+  return safeHtml(`<td style="text-align:left;padding:6px 12px;border-bottom:1px solid #e2e8f0;font-size:14px;">${flatten(children)}</td>`);
 }

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource emails */
-import { flatten } from "../jsx-runtime";
+import { escapeAttr, flatten } from "../jsx-runtime";
 
 export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?: any }) {
   const styles: Record<number, string> = {
@@ -12,7 +12,7 @@ export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?:
 
 export function Paragraph({ style, children }: { style?: string; children?: any }) {
   const s = style ?? "font-size:14px;line-height:1.5;margin:8px 0;";
-  return `<p style="${s}">${flatten(children)}</p>\n`;
+  return `<p style="${escapeAttr(s)}">${flatten(children)}</p>\n`;
 }
 
 export function Code({ children }: { children?: any }) {
@@ -23,8 +23,23 @@ export function Bold({ children }: { children?: any }) {
   return `<strong>${flatten(children)}</strong>`;
 }
 
+const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function safeHref(href: string): string {
+  const trimmed = href.trim();
+  try {
+    const url = new URL(trimmed);
+    if (ALLOWED_LINK_PROTOCOLS.has(url.protocol)) {
+      return trimmed;
+    }
+  } catch {
+    // Relative or malformed URLs are not useful in email; fall through.
+  }
+  return "#";
+}
+
 export function Link({ href, children }: { href: string; children?: any }) {
-  return `<a href="${href}" style="color:#2563eb;text-decoration:none;">${flatten(children)}</a>`;
+  return `<a href="${escapeAttr(safeHref(href))}" style="color:#2563eb;text-decoration:none;">${flatten(children)}</a>`;
 }
 
 export function HR() {

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -2,6 +2,10 @@
 import { escapeAttr, flatten, safeHtml } from "../jsx-runtime";
 
 export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?: any }) {
+  if (level !== 1 && level !== 2 && level !== 3) {
+    throw new TypeError("Heading level must be 1, 2, or 3");
+  }
+
   const styles: Record<number, string> = {
     1: "font-size:20px;border-bottom:2px solid #333;padding-bottom:8px;margin:24px 0 12px 0;",
     2: "font-size:16px;color:#555;margin:24px 0 8px 0;",
@@ -51,5 +55,9 @@ export function LineBreak() {
 }
 
 export function Spacer({ height = 16 }: { height?: number }) {
+  if (typeof height !== "number" || !Number.isFinite(height) || height < 0) {
+    throw new TypeError("Spacer height must be a finite non-negative number");
+  }
+
   return safeHtml(`<div style="height:${height}px;"></div>\n`);
 }

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource emails */
-import { escapeAttr, flatten } from "../jsx-runtime";
+import { escapeAttr, flatten, safeHtml } from "../jsx-runtime";
 
 export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?: any }) {
   const styles: Record<number, string> = {
@@ -7,20 +7,20 @@ export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?:
     2: "font-size:16px;color:#555;margin:24px 0 8px 0;",
     3: "font-size:14px;color:#555;margin:16px 0 6px 0;",
   };
-  return `<h${level} style="${styles[level]}">${flatten(children)}</h${level}>\n`;
+  return safeHtml(`<h${level} style="${styles[level]}">${flatten(children)}</h${level}>\n`);
 }
 
 export function Paragraph({ style, children }: { style?: string; children?: any }) {
   const s = style ?? "font-size:14px;line-height:1.5;margin:8px 0;";
-  return `<p style="${escapeAttr(s)}">${flatten(children)}</p>\n`;
+  return safeHtml(`<p style="${escapeAttr(s)}">${flatten(children)}</p>\n`);
 }
 
 export function Code({ children }: { children?: any }) {
-  return `<code style="background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:13px;">${flatten(children)}</code>`;
+  return safeHtml(`<code style="background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:13px;">${flatten(children)}</code>`);
 }
 
 export function Bold({ children }: { children?: any }) {
-  return `<strong>${flatten(children)}</strong>`;
+  return safeHtml(`<strong>${flatten(children)}</strong>`);
 }
 
 const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
@@ -39,17 +39,17 @@ function safeHref(href: string): string {
 }
 
 export function Link({ href, children }: { href: string; children?: any }) {
-  return `<a href="${escapeAttr(safeHref(href))}" style="color:#2563eb;text-decoration:none;">${flatten(children)}</a>`;
+  return safeHtml(`<a href="${escapeAttr(safeHref(href))}" style="color:#2563eb;text-decoration:none;">${flatten(children)}</a>`);
 }
 
 export function HR() {
-  return `<hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;" />\n`;
+  return safeHtml(`<hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;" />\n`);
 }
 
 export function LineBreak() {
-  return `<br />\n`;
+  return safeHtml(`<br />\n`);
 }
 
 export function Spacer({ height = 16 }: { height?: number }) {
-  return `<div style="height:${height}px;"></div>\n`;
+  return safeHtml(`<div style="height:${height}px;"></div>\n`);
 }

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource emails */
+import { flatten } from "../jsx-runtime";
+
+export function Heading({ level = 1, children }: { level?: 1 | 2 | 3; children?: any }) {
+  const styles: Record<number, string> = {
+    1: "font-size:20px;border-bottom:2px solid #333;padding-bottom:8px;margin:24px 0 12px 0;",
+    2: "font-size:16px;color:#555;margin:24px 0 8px 0;",
+    3: "font-size:14px;color:#555;margin:16px 0 6px 0;",
+  };
+  return `<h${level} style="${styles[level]}">${flatten(children)}</h${level}>\n`;
+}
+
+export function Paragraph({ style, children }: { style?: string; children?: any }) {
+  const s = style ?? "font-size:14px;line-height:1.5;margin:8px 0;";
+  return `<p style="${s}">${flatten(children)}</p>\n`;
+}
+
+export function Code({ children }: { children?: any }) {
+  return `<code style="background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:13px;">${flatten(children)}</code>`;
+}
+
+export function Bold({ children }: { children?: any }) {
+  return `<strong>${flatten(children)}</strong>`;
+}
+
+export function Link({ href, children }: { href: string; children?: any }) {
+  return `<a href="${href}" style="color:#2563eb;text-decoration:none;">${flatten(children)}</a>`;
+}
+
+export function HR() {
+  return `<hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;" />\n`;
+}
+
+export function LineBreak() {
+  return `<br />\n`;
+}
+
+export function Spacer({ height = 16 }: { height?: number }) {
+  return `<div style="height:${height}px;"></div>\n`;
+}

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,0 +1,38 @@
+// email() — wraps email body content in HTML boilerplate.
+//
+// Usage in a .tsx file:
+//   import { email } from "emails/src/email";
+//   const output = email({ body: <Section title="Report">...</Section> });
+//   console.log(output);
+
+export interface EmailOptions {
+  body: string;
+  format?: "html" | "text";
+}
+
+export function email({ body, format = "html" }: EmailOptions): string {
+  if (format === "text") {
+    return body;
+  }
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: #1a1a1a;
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 20px;
+    line-height: 1.5;
+  }
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}

--- a/src/email.ts
+++ b/src/email.ts
@@ -5,15 +5,19 @@
 //   const output = email({ body: <Section title="Report">...</Section> });
 //   console.log(output);
 
+import { flatten } from "./jsx-runtime";
+
 export interface EmailOptions {
-  body: string;
+  body: any;
   format?: "html" | "text";
 }
 
 export function email({ body, format = "html" }: EmailOptions): string {
   if (format === "text") {
-    return body;
+    return String(body);
   }
+
+  const renderedBody = flatten(body);
 
   return `<!DOCTYPE html>
 <html>
@@ -32,7 +36,7 @@ export function email({ body, format = "html" }: EmailOptions): string {
 </style>
 </head>
 <body>
-${body}
+${renderedBody}
 </body>
 </html>`;
 }

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,2 @@
+export { jsx, jsxs, Fragment } from "./jsx-runtime";
+export { jsx as jsxDEV } from "./jsx-runtime";

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,26 @@
+// Custom JSX runtime that renders to HTML strings (for email).
+//
+// Same pattern as readme's jsx-runtime, but components produce
+// inline-styled HTML instead of Markdown.
+
+export function jsx(
+  tag: string | Function,
+  props: Record<string, any>,
+): string {
+  if (typeof tag === "function") {
+    return tag(props);
+  }
+  throw new Error(`Unknown intrinsic element: <${tag}>. Use a component instead.`);
+}
+
+export const jsxs = jsx;
+
+export function flatten(c: any): string {
+  if (c == null) return "";
+  if (Array.isArray(c)) return c.map(flatten).join("");
+  return String(c);
+}
+
+export function Fragment({ children }: { children?: any }): string {
+  return flatten(children);
+}

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -32,7 +32,7 @@ export function jsx(
 ): SafeHtml {
   if (typeof tag === "function") {
     const rendered = tag(props ?? {});
-    return rendered instanceof SafeHtml ? rendered : safeHtml(String(rendered));
+    return rendered instanceof SafeHtml ? rendered : safeHtml(flatten(rendered));
   }
   throw new Error(`Unknown intrinsic element: <${tag}>. Use a component instead.`);
 }
@@ -53,6 +53,6 @@ export function flattenRaw(c: any): string {
   return String(c);
 }
 
-export function Fragment({ children }: { children?: any }): string {
-  return flatten(children);
+export function Fragment({ children }: { children?: any }): SafeHtml {
+  return safeHtml(flatten(children));
 }

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -3,12 +3,36 @@
 // Same pattern as readme's jsx-runtime, but components produce
 // inline-styled HTML instead of Markdown.
 
+export class SafeHtml extends String {
+  readonly __safeHtml = true;
+
+  constructor(public readonly html: string) {
+    super(html);
+  }
+}
+
+export function safeHtml(html: string): SafeHtml {
+  return new SafeHtml(html);
+}
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export const escapeAttr = escapeHtml;
+
 export function jsx(
   tag: string | Function,
   props: Record<string, any>,
-): string {
+): SafeHtml {
   if (typeof tag === "function") {
-    return tag(props);
+    const rendered = tag(props ?? {});
+    return rendered instanceof SafeHtml ? rendered : safeHtml(String(rendered));
   }
   throw new Error(`Unknown intrinsic element: <${tag}>. Use a component instead.`);
 }
@@ -16,8 +40,16 @@ export function jsx(
 export const jsxs = jsx;
 
 export function flatten(c: any): string {
-  if (c == null) return "";
+  if (c == null || c === false) return "";
+  if (c instanceof SafeHtml) return c.html;
   if (Array.isArray(c)) return c.map(flatten).join("");
+  return escapeHtml(String(c));
+}
+
+export function flattenRaw(c: any): string {
+  if (c == null || c === false) return "";
+  if (c instanceof SafeHtml) return c.html;
+  if (Array.isArray(c)) return c.map(flattenRaw).join("");
   return String(c);
 }
 

--- a/test/compose.bats
+++ b/test/compose.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# Tests for emails compose task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  export MISE_CONFIG_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  setup_agent
+}
+
+# ============================================================================
+# Basic compose
+# ============================================================================
+
+@test "compose: renders a simple TSX file to HTML" {
+  cat > "$BATS_TEST_TMPDIR/simple.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Heading, Paragraph } from "emails";
+
+const body = (
+  <>
+    <Heading>Hello</Heading>
+    <Paragraph>World</Paragraph>
+  </>
+);
+console.log(email({ body }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/simple.tsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<!DOCTYPE html>"* ]]
+  [[ "$output" == *"<h1"* ]]
+  [[ "$output" == *"Hello"* ]]
+  [[ "$output" == *"World"* ]]
+}
+
+@test "compose: passes arguments to TSX file" {
+  cat > "$BATS_TEST_TMPDIR/args.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import { Heading } from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: { name: { type: "string" } },
+  strict: true,
+});
+
+console.log(email({ body: <Heading>{values.name}</Heading> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/args.tsx" --name "Alice"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Alice"* ]]
+}
+
+@test "compose: supports multiple repeated args" {
+  cat > "$BATS_TEST_TMPDIR/multi.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import { List, Item } from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: { item: { type: "string", multiple: true, default: [] } },
+  strict: true,
+});
+
+const body = <List>{values.item!.map((i: string) => <Item>{i}</Item>)}</List>;
+console.log(email({ body }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/multi.tsx" --item "one" --item "two" --item "three"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"one"* ]]
+  [[ "$output" == *"two"* ]]
+  [[ "$output" == *"three"* ]]
+}
+
+@test "compose: text format skips HTML boilerplate" {
+  cat > "$BATS_TEST_TMPDIR/text.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+
+console.log(email({ body: "Just plain text.", format: "text" }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/text.tsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Just plain text." ]]
+}
+
+# ============================================================================
+# Components available
+# ============================================================================
+
+@test "compose: Card component renders" {
+  cat > "$BATS_TEST_TMPDIR/card.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Card } from "emails";
+
+console.log(email({ body: <Card variant="success" title="Done">Details</Card> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/card.tsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#f0fdf4"* ]]
+  [[ "$output" == *"Done"* ]]
+  [[ "$output" == *"Details"* ]]
+}
+
+@test "compose: Table component renders" {
+  cat > "$BATS_TEST_TMPDIR/table.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Table, Row, Cell, HeaderCell } from "emails";
+
+const body = (
+  <Table>
+    <Row><HeaderCell>Name</HeaderCell></Row>
+    <Row><Cell>Alice</Cell></Row>
+  </Table>
+);
+console.log(email({ body }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/table.tsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<table"* ]]
+  [[ "$output" == *"Alice"* ]]
+}
+
+# ============================================================================
+# Error handling
+# ============================================================================
+
+@test "compose: fails on missing file" {
+  run emails compose /nonexistent/file.tsx
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "compose: fails without arguments" {
+  run emails compose
+  [ "$status" -ne 0 ]
+}
+
+# ============================================================================
+# Example templates
+# ============================================================================
+
+@test "compose: session-report example runs" {
+  run emails compose "$MISE_CONFIG_ROOT/examples/session-report.tsx" \
+    --agent test-agent \
+    --shipped "feature: details here" \
+    --next "do more stuff"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test-agent"* ]]
+  [[ "$output" == *"feature"* ]]
+  [[ "$output" == *"do more stuff"* ]]
+}
+
+@test "compose: alert example runs" {
+  run emails compose "$MISE_CONFIG_ROOT/examples/alert.tsx" \
+    --severity warning \
+    --title "Disk almost full" \
+    --detail "92% used on /dev/sda1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Disk almost full"* ]]
+  [[ "$output" == *"🟡"* ]]
+}
+
+@test "compose: review-request example runs" {
+  run emails compose "$MISE_CONFIG_ROOT/examples/review-request.tsx" \
+    --repo test/repo \
+    --pr 42 \
+    --reviewer alice \
+    --summary "big change"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Review request"* ]]
+  [[ "$output" == *"alice"* ]]
+  [[ "$output" == *"#42"* ]]
+}

--- a/test/compose.bats
+++ b/test/compose.bats
@@ -138,6 +138,32 @@ TSX
   [[ "$output" != *"javascript:"* ]]
 }
 
+@test "compose: custom component string returns are escaped" {
+  cat > "$BATS_TEST_TMPDIR/custom.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import { Paragraph } from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: { title: { type: "string" } },
+  strict: true,
+});
+
+function UserText({ value }: { value: string }) {
+  return value;
+}
+
+console.log(email({ body: <Paragraph><UserText value={values.title!} /></Paragraph> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/custom.tsx" --title '<script>alert("x")</script> & ok'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; ok"* ]]
+  [[ "$output" != *"<script>"* ]]
+}
+
 # ============================================================================
 # Components available
 # ============================================================================

--- a/test/compose.bats
+++ b/test/compose.bats
@@ -94,6 +94,50 @@ TSX
   [[ "$output" == "Just plain text." ]]
 }
 
+@test "compose: escapes dynamic text by default" {
+  cat > "$BATS_TEST_TMPDIR/escape.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { parseArgs } from "util";
+import { email } from "emails/src/email";
+import { Paragraph, Raw } from "emails";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: { title: { type: "string" } },
+  strict: true,
+});
+
+const body = (
+  <>
+    <Paragraph>{values.title}</Paragraph>
+    <Raw>{"<strong>trusted</strong>"}</Raw>
+  </>
+);
+console.log(email({ body }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/escape.tsx" --title '<script>alert("x")</script> & ok'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; ok"* ]]
+  [[ "$output" != *"<script>"* ]]
+  [[ "$output" == *"<strong>trusted</strong>"* ]]
+}
+
+@test "compose: rejects unsafe link protocols" {
+  cat > "$BATS_TEST_TMPDIR/link.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Link } from "emails";
+
+console.log(email({ body: <Link href={'javascript:alert(1)'}>click</Link> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/link.tsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'href="#"'* ]]
+  [[ "$output" != *"javascript:"* ]]
+}
+
 # ============================================================================
 # Components available
 # ============================================================================

--- a/test/compose.bats
+++ b/test/compose.bats
@@ -215,6 +215,34 @@ TSX
   [[ "$output" == *"not found"* ]]
 }
 
+@test "compose: rejects invalid Heading level at runtime" {
+  cat > "$BATS_TEST_TMPDIR/bad-heading.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Heading } from "emails";
+
+console.log(email({ body: <Heading level={'1 onclick="alert(1)' as any}>Bad</Heading> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/bad-heading.tsx"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Heading level must be 1, 2, or 3"* ]]
+}
+
+@test "compose: rejects invalid Spacer height at runtime" {
+  cat > "$BATS_TEST_TMPDIR/bad-spacer.tsx" <<'TSX'
+/** @jsxImportSource emails */
+import { email } from "emails/src/email";
+import { Spacer } from "emails";
+
+console.log(email({ body: <Spacer height={'1" onclick="alert(1)' as any} /> }));
+TSX
+
+  run emails compose "$BATS_TEST_TMPDIR/bad-spacer.tsx"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Spacer height must be a finite non-negative number"* ]]
+}
+
 @test "compose: fails without arguments" {
   run emails compose
   [ "$status" -ne 0 ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "emails",
+    "paths": {
+      "emails/jsx-runtime": ["./src/jsx-runtime.ts"],
+      "emails/jsx-dev-runtime": ["./src/jsx-dev-runtime.ts"],
+      "emails": ["./src/components/index.ts"],
+      "emails/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
## What

JSX runtime + component library for composing HTML emails from TSX files. Same pattern as KnickKnackLabs/readme but rendering inline-styled HTML instead of Markdown.

## How it works

```bash
emails compose report.tsx --agent x1f9 --date 2026-04-04
```

The TSX file is a self-contained bun script:
- Parses its own CLI args via `util.parseArgs` (Node stdlib, no deps)
- Imports email components from `emails`
- Calls `email({ body })` to wrap in HTML boilerplate
- Outputs HTML to stdout

Pipe to `emails send`:
```bash
emails compose report.tsx --agent x1f9 | emails send --to rikonor@gmail.com --subject 'report' --html
```

## Components

Heading, Paragraph, Bold, Code, Link, HR, LineBreak, Spacer, Card (success/warning/info/error), Table/Row/Cell/HeaderCell, Stats/Stat, Section, List/Item, Footer, Raw.

All components use inline CSS for email client compatibility.

## Examples

4 example templates in `examples/`:
- **session-report.tsx** — `--shipped` / `--next` flags
- **review-request.tsx** — `--repo` / `--pr` / `--reviewer` / `--concern`
- **alert.tsx** — `--severity` / `--detail` / `--action`
- **digest.tsx** — fetches live PR data from GitHub at compose time via `gh`

## Tests

- 31 bun:test component tests
- 11 BATS integration tests (compose task, arg passing, examples)