### PR TITLE
mise: align with KKL conventions

### DIFF
--- a/.mise/tasks/archive
+++ b/.mise/tasks/archive
@@ -2,11 +2,11 @@
 #MISE description="Archive email message(s)"
 #USAGE arg "<id>" help="Message ID to archive"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-ID="$1"
+ID="$usage_id"
 
 if [ -z "$ID" ]; then
   echo "Usage: emails archive <id>"

--- a/.mise/tasks/compose
+++ b/.mise/tasks/compose
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Compose an email from a TSX file"
 #USAGE arg "<file>" help="Path to .tsx file"
-#USAGE arg "[args]" var=#true help="Arguments to pass to the TSX file"
+#USAGE arg "[args]" var=#true default="" help="Arguments to pass to the TSX file"
 
 set -euo pipefail
 

--- a/.mise/tasks/delete
+++ b/.mise/tasks/delete
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Delete email message(s) (moves to Trash)"
-#USAGE arg "[ids...]" var=#true help="Message ID(s) to delete"
-#USAGE flag "--all" help="Delete all messages in folder"
-#USAGE flag "--permanent" help="Permanently delete (skip Trash, purge immediately)"
-#USAGE flag "-f --folder <folder>" help="Folder to operate on (default: INBOX)"
+#USAGE arg "[ids]" var=#true default="" help="Message ID(s) to delete"
+#USAGE flag "--all" default=#false help="Delete all messages in folder"
+#USAGE flag "--permanent" default=#false help="Permanently delete (skip Trash, purge immediately)"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to operate on (default: INBOX)"
 
 set -euo pipefail
 
@@ -14,12 +14,23 @@ PERMANENT="${usage_permanent:-false}"
 FOLDER="${usage_folder:-INBOX}"
 
 # Parse variadic args
-IDS_RAW="${usage_ids:-}"
-if [ -n "$IDS_RAW" ] && [[ ! "$IDS_RAW" =~ ^[0-9[:space:]]+$ ]]; then
-  echo "Error: IDs must be numeric (got: $IDS_RAW)"
-  exit 1
+IDS=()
+IDS_COUNT=0
+while IFS= read -r id; do
+  if [ -n "$id" ]; then
+    IDS+=("$id")
+    IDS_COUNT=$((IDS_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_ids:-}" | xargs printf '%s\n')
+
+if [ "$IDS_COUNT" -gt 0 ]; then
+  for id in "${IDS[@]}"; do
+    if [[ ! "$id" =~ ^[0-9]+$ ]]; then
+      echo "Error: IDs must be numeric (got: $id)"
+      exit 1
+    fi
+  done
 fi
-read -ra IDS <<< "$IDS_RAW"
 
 # Reject non-permanent delete from Trash
 if echo "$FOLDER" | grep -qi '^trash$' && [ "$PERMANENT" != "true" ]; then
@@ -29,7 +40,7 @@ if echo "$FOLDER" | grep -qi '^trash$' && [ "$PERMANENT" != "true" ]; then
   exit 1
 fi
 
-if [ ${#IDS[@]} -eq 0 ] && [ "$ALL" != "true" ]; then
+if [ "$IDS_COUNT" -eq 0 ] && [ "$ALL" != "true" ]; then
   echo "Usage: emails delete <id> [id...]"
   echo "       emails delete --all [-f <folder>]"
   echo ""
@@ -40,23 +51,27 @@ fi
 # --all mode: enumerate all IDs from the folder
 if [ "$ALL" = "true" ]; then
   IDS=()
+  IDS_COUNT=0
   while IFS= read -r id; do
-    [ -n "$id" ] && IDS+=("$id")
+    if [ -n "$id" ]; then
+      IDS+=("$id")
+      IDS_COUNT=$((IDS_COUNT + 1))
+    fi
   done < <("$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$FOLDER" --page-size 1000 2>/dev/null \
     | tail -n +4 | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}' | grep -E '^[0-9]+$')
 
-  if [ ${#IDS[@]} -eq 0 ]; then
+  if [ "$IDS_COUNT" -eq 0 ]; then
     echo "$FOLDER is empty"
     exit 0
   fi
-  echo "Deleting ${#IDS[@]} message(s) from $FOLDER..."
+  echo "Deleting $IDS_COUNT message(s) from $FOLDER..."
 fi
 
 if [ "$PERMANENT" = "true" ]; then
   "$HIMALAYA_BIN" flag add -a "$AGENT" -f "$FOLDER" "${IDS[@]}" deleted
   "$HIMALAYA_BIN" folder expunge -a "$AGENT" "$FOLDER"
-  echo "Permanently deleted ${#IDS[@]} message(s) from $FOLDER"
+  echo "Permanently deleted $IDS_COUNT message(s) from $FOLDER"
 else
   "$HIMALAYA_BIN" message delete -a "$AGENT" -f "$FOLDER" "${IDS[@]}"
-  echo "Moved ${#IDS[@]} message(s) to Trash"
+  echo "Moved $IDS_COUNT message(s) to Trash"
 fi

--- a/.mise/tasks/delete
+++ b/.mise/tasks/delete
@@ -5,7 +5,7 @@
 #USAGE flag "--permanent" help="Permanently delete (skip Trash, purge immediately)"
 #USAGE flag "-f --folder <folder>" help="Folder to operate on (default: INBOX)"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
@@ -14,11 +14,12 @@ PERMANENT="${usage_permanent:-false}"
 FOLDER="${usage_folder:-INBOX}"
 
 # Parse variadic args
-if [ -n "$usage_ids" ] && [[ ! "$usage_ids" =~ ^[0-9[:space:]]+$ ]]; then
-  echo "Error: IDs must be numeric (got: $usage_ids)"
+IDS_RAW="${usage_ids:-}"
+if [ -n "$IDS_RAW" ] && [[ ! "$IDS_RAW" =~ ^[0-9[:space:]]+$ ]]; then
+  echo "Error: IDs must be numeric (got: $IDS_RAW)"
   exit 1
 fi
-read -ra IDS <<< "$usage_ids"
+read -ra IDS <<< "$IDS_RAW"
 
 # Reject non-permanent delete from Trash
 if echo "$FOLDER" | grep -qi '^trash$' && [ "$PERMANENT" != "true" ]; then

--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -6,7 +6,7 @@
 #USAGE flag "-f --folder <folder>" help="Folder to export from (default: INBOX)"
 #USAGE flag "-n --limit <limit>" help="Limit number of emails when using --all (default: 500)"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
@@ -16,11 +16,12 @@ LIMIT="${usage_limit:-500}"
 ALL="${usage_all:-false}"
 
 # Parse variadic args
-if [ -n "$usage_ids" ] && [[ ! "$usage_ids" =~ ^[0-9[:space:]]+$ ]]; then
-  echo "Error: IDs must be numeric (got: $usage_ids)"
+IDS_RAW="${usage_ids:-}"
+if [ -n "$IDS_RAW" ] && [[ ! "$IDS_RAW" =~ ^[0-9[:space:]]+$ ]]; then
+  echo "Error: IDs must be numeric (got: $IDS_RAW)"
   exit 1
 fi
-read -ra IDS <<< "$usage_ids"
+read -ra IDS <<< "$IDS_RAW"
 
 # Create destination directory
 mkdir -p "$DEST"

--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Export emails to a directory"
-#USAGE arg "[ids...]" var=#true help="Message IDs to export"
-#USAGE flag "--all" help="Export all messages in folder"
-#USAGE flag "-d --destination <path>" help="Directory to export to (default: ./emails)"
-#USAGE flag "-f --folder <folder>" help="Folder to export from (default: INBOX)"
-#USAGE flag "-n --limit <limit>" help="Limit number of emails when using --all (default: 500)"
+#USAGE arg "[ids]" var=#true default="" help="Message IDs to export"
+#USAGE flag "--all" default=#false help="Export all messages in folder"
+#USAGE flag "-d --destination <path>" default="./emails" help="Directory to export to (default: ./emails)"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to export from (default: INBOX)"
+#USAGE flag "-n --limit <limit>" default="500" help="Limit number of emails when using --all (default: 500)"
 
 set -euo pipefail
 
@@ -16,31 +16,46 @@ LIMIT="${usage_limit:-500}"
 ALL="${usage_all:-false}"
 
 # Parse variadic args
-IDS_RAW="${usage_ids:-}"
-if [ -n "$IDS_RAW" ] && [[ ! "$IDS_RAW" =~ ^[0-9[:space:]]+$ ]]; then
-  echo "Error: IDs must be numeric (got: $IDS_RAW)"
-  exit 1
+IDS=()
+IDS_COUNT=0
+while IFS= read -r id; do
+  if [ -n "$id" ]; then
+    IDS+=("$id")
+    IDS_COUNT=$((IDS_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_ids:-}" | xargs printf '%s\n')
+
+if [ "$IDS_COUNT" -gt 0 ]; then
+  for id in "${IDS[@]}"; do
+    if [[ ! "$id" =~ ^[0-9]+$ ]]; then
+      echo "Error: IDs must be numeric (got: $id)"
+      exit 1
+    fi
+  done
 fi
-read -ra IDS <<< "$IDS_RAW"
 
 # Create destination directory
 mkdir -p "$DEST"
 
 # Get message IDs
-if [ ${#IDS[@]} -eq 0 ] || [ "$ALL" = "true" ]; then
+if [ "$IDS_COUNT" -eq 0 ] || [ "$ALL" = "true" ]; then
   echo "Fetching message list from $FOLDER..."
   IDS=()
+  IDS_COUNT=0
   while IFS= read -r id; do
-    [ -n "$id" ] && IDS+=("$id")
+    if [ -n "$id" ]; then
+      IDS+=("$id")
+      IDS_COUNT=$((IDS_COUNT + 1))
+    fi
   done < <("$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$FOLDER" --page-size "$LIMIT" 2>/dev/null | tail -n +4 | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}' | grep -E '^[0-9]+$')
 fi
 
-if [ ${#IDS[@]} -eq 0 ]; then
+if [ "$IDS_COUNT" -eq 0 ]; then
   echo "No messages to export"
   exit 0
 fi
 
-echo "Exporting ${#IDS[@]} message(s) from $FOLDER to $DEST..."
+echo "Exporting $IDS_COUNT message(s) from $FOLDER to $DEST..."
 
 EXPORTED=0
 FAILED=0

--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -61,11 +61,11 @@ EXPORTED=0
 FAILED=0
 for ID in "${IDS[@]}"; do
   if "$HIMALAYA_BIN" message read -a "$AGENT" -f "$FOLDER" "$ID" > "$DEST/$ID.eml" 2>/dev/null; then
-    ((EXPORTED++))
+    EXPORTED=$((EXPORTED + 1))
   else
     echo "  Failed: $ID"
     rm -f "$DEST/$ID.eml"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
   fi
 done
 

--- a/.mise/tasks/inspect
+++ b/.mise/tasks/inspect
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Inspect email message structure and metadata"
 #USAGE arg "<id>" help="Message ID to inspect"
-#USAGE flag "-f --folder <folder>" help="Folder to inspect from (default: INBOX)"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to inspect from (default: INBOX)"
 
 set -euo pipefail
 

--- a/.mise/tasks/inspect
+++ b/.mise/tasks/inspect
@@ -3,9 +3,9 @@
 #USAGE arg "<id>" help="Message ID to inspect"
 #USAGE flag "-f --folder <folder>" help="Folder to inspect from (default: INBOX)"
 
-set -e
+set -euo pipefail
 
-ID="${usage_id:-$1}"
+ID="$usage_id"
 FOLDER="${usage_folder:-INBOX}"
 
 if [ -z "$ID" ]; then

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -6,7 +6,7 @@
 #USAGE flag "--unread" help="Only show unread messages"
 #USAGE flag "--count" help="Just output the count (useful for scripts)"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="List email messages"
-#USAGE flag "-n --limit <limit>" help="Number of messages to show (default: 10)"
-#USAGE flag "-f --folder <folder>" help="Folder to list (default: INBOX)"
-#USAGE flag "-p --page <page>" help="Page number, starting from 1 (default: 1)"
-#USAGE flag "--unread" help="Only show unread messages"
-#USAGE flag "--count" help="Just output the count (useful for scripts)"
+#USAGE flag "-n --limit <limit>" default="10" help="Number of messages to show (default: 10)"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to list (default: INBOX)"
+#USAGE flag "-p --page <page>" default="1" help="Page number, starting from 1 (default: 1)"
+#USAGE flag "--unread" default=#false help="Only show unread messages"
+#USAGE flag "--count" default=#false help="Just output the count (useful for scripts)"
 
 set -euo pipefail
 

--- a/.mise/tasks/purge
+++ b/.mise/tasks/purge
@@ -3,7 +3,7 @@
 #USAGE arg "[folder]" help="Folder to purge (default: Trash)"
 #USAGE flag "--force" help="Skip confirmation prompt"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 

--- a/.mise/tasks/purge
+++ b/.mise/tasks/purge
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Permanently delete all messages in a folder"
-#USAGE arg "[folder]" help="Folder to purge (default: Trash)"
-#USAGE flag "--force" help="Skip confirmation prompt"
+#USAGE arg "[folder]" default="Trash" help="Folder to purge (default: Trash)"
+#USAGE flag "--force" default=#false help="Skip confirmation prompt"
 
 set -euo pipefail
 

--- a/.mise/tasks/quota
+++ b/.mise/tasks/quota
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show email storage quota usage"
 
-set -e
+set -euo pipefail
 
 NEED_IMAP=1 source "$MISE_CONFIG_ROOT/lib/email.sh"
 

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -4,11 +4,11 @@
 #USAGE flag "-f --folder <folder>" help="Folder to read from (default: INBOX)"
 #USAGE flag "-s --save-attachments" help="Download attachments to agent workspace"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-ID="${usage_id:-$1}"
+ID="$usage_id"
 FOLDER="${usage_folder:-INBOX}"
 
 if [ -z "$ID" ]; then

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Read an email message"
 #USAGE arg "<id>" help="Message ID to read"
-#USAGE flag "-f --folder <folder>" help="Folder to read from (default: INBOX)"
-#USAGE flag "-s --save-attachments" help="Download attachments to agent workspace"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to read from (default: INBOX)"
+#USAGE flag "-s --save-attachments" default=#false help="Download attachments to agent workspace"
 
 set -euo pipefail
 

--- a/.mise/tasks/reply
+++ b/.mise/tasks/reply
@@ -8,12 +8,12 @@
 #USAGE flag "--allow-short" help="Allow short reply bodies (under 50 chars)"
 #USAGE flag "--html" help="Send reply as HTML (Content-Type: text/html)"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-ID="${usage_id:-$1}"
-BODY="${usage_body:-${2:-}}"
+ID="$usage_id"
+BODY="${usage_body:-}"
 
 if [ -z "$ID" ]; then
   echo "Usage: emails reply <id> [body]"

--- a/.mise/tasks/reply
+++ b/.mise/tasks/reply
@@ -3,10 +3,10 @@
 #USAGE arg "<id>" help="Message ID to reply to"
 #USAGE arg "[body]" help="Reply body (optional, or use -b flag or stdin)"
 #USAGE flag "-b --body <body>" help="Reply body (alternative to positional arg)"
-#USAGE flag "-c --cc <cc>" help="CC recipient (repeatable)" var=#true
-#USAGE flag "-a --attach <attach>" help="File path to attach (repeatable)" var=#true
-#USAGE flag "--allow-short" help="Allow short reply bodies (under 50 chars)"
-#USAGE flag "--html" help="Send reply as HTML (Content-Type: text/html)"
+#USAGE flag "-c --cc <cc>" var=#true default="" help="CC recipient (repeatable)"
+#USAGE flag "-a --attach <attach>" var=#true default="" help="File path to attach (repeatable)"
+#USAGE flag "--allow-short" default=#false help="Allow short reply bodies (under 50 chars)"
+#USAGE flag "--html" default=#false help="Send reply as HTML (Content-Type: text/html)"
 
 set -euo pipefail
 
@@ -62,8 +62,17 @@ fi
 
 # Build attachment MML parts and validate files
 ATTACH_MML=""
-if [ -n "${usage_attach:-}" ]; then
-  while IFS= read -r filepath; do
+ATTACHES=()
+ATTACH_COUNT=0
+while IFS= read -r filepath; do
+  if [ -n "$filepath" ]; then
+    ATTACHES+=("$filepath")
+    ATTACH_COUNT=$((ATTACH_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_attach:-}" | xargs printf '%s\n')
+
+if [ "$ATTACH_COUNT" -gt 0 ]; then
+  for filepath in "${ATTACHES[@]}"; do
     if [[ "$filepath" != /* ]]; then
       filepath="$(cd "$(dirname "$filepath")" && pwd)/$(basename "$filepath")"
     fi
@@ -74,7 +83,7 @@ if [ -n "${usage_attach:-}" ]; then
     ATTACH_MML="${ATTACH_MML}
 <#part filename=\"${filepath}\"><#/part>"
     echo "Attaching: $(basename "$filepath") ($(du -h "$filepath" | cut -f1 | tr -d ' '))"
-  done < <(echo "$usage_attach" | xargs -n1 printf '%s\n')
+  done
 fi
 
 # Get reply template headers
@@ -90,8 +99,17 @@ if [ -z "$REPLY_TO" ]; then
 fi
 
 # Add CC header if specified
-if [ -n "${usage_cc:-}" ]; then
-  CC_ADDRS=$(echo "$usage_cc" | xargs -n1 printf '%s\n' | paste -sd ',' - | sed 's/,/, /g')
+CCS=()
+CC_COUNT=0
+while IFS= read -r cc; do
+  if [ -n "$cc" ]; then
+    CCS+=("$cc")
+    CC_COUNT=$((CC_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_cc:-}" | xargs printf '%s\n')
+
+if [ "$CC_COUNT" -gt 0 ]; then
+  CC_ADDRS=$(printf '%s\n' "${CCS[@]}" | paste -sd ',' - | sed 's/,/, /g')
   HEADERS=$(echo "$HEADERS" | sed "/^Subject:/a\\\nCc: $CC_ADDRS")
 fi
 

--- a/.mise/tasks/reply
+++ b/.mise/tasks/reply
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Reply to an email message"
 #USAGE arg "<id>" help="Message ID to reply to"
-#USAGE arg "[body]" help="Reply body (optional, or use -b flag or stdin)"
-#USAGE flag "-b --body <body>" help="Reply body (alternative to positional arg)"
+#USAGE arg "[body_arg]" default="" help="Reply body (optional, or use -b flag or stdin)"
+#USAGE flag "-b --body <body>" default="" help="Reply body (alternative to positional arg)"
 #USAGE flag "-c --cc <cc>" var=#true default="" help="CC recipient (repeatable)"
 #USAGE flag "-a --attach <attach>" var=#true default="" help="File path to attach (repeatable)"
 #USAGE flag "--allow-short" default=#false help="Allow short reply bodies (under 50 chars)"
@@ -13,7 +13,17 @@ set -euo pipefail
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
 ID="$usage_id"
-BODY="${usage_body:-}"
+
+# Body from positional arg or -b/--body flag. The positional arg is named
+# `body_arg` so it does not collide with the flag's `usage_body`; defaults on
+# both values clear inherited parent `usage_*` env.
+BODY_ARG="${usage_body_arg:-}"
+BODY_FLAG="${usage_body:-}"
+if [ -n "$BODY_ARG" ] && [ -n "$BODY_FLAG" ]; then
+  echo "Error: Provide reply body either positionally or with -b/--body, not both"
+  exit 1
+fi
+BODY="${BODY_FLAG:-$BODY_ARG}"
 
 if [ -z "$ID" ]; then
   echo "Usage: emails reply <id> [body]"

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -4,10 +4,10 @@
 #USAGE arg "<subject>" help="Email subject"
 #USAGE arg "[body]" help="Message body (optional, or use -b flag or stdin)"
 #USAGE flag "-b --body <body>" help="Message body (alternative to positional arg)"
-#USAGE flag "-c --cc <cc>" help="CC recipient (repeatable)" var=#true
-#USAGE flag "-a --attach <attach>" help="File path to attach (repeatable)" var=#true
-#USAGE flag "--allow-short" help="Allow short message bodies (under 50 chars)"
-#USAGE flag "--html" help="Send body as HTML (Content-Type: text/html)"
+#USAGE flag "-c --cc <cc>" var=#true default="" help="CC recipient (repeatable)"
+#USAGE flag "-a --attach <attach>" var=#true default="" help="File path to attach (repeatable)"
+#USAGE flag "--allow-short" default=#false help="Allow short message bodies (under 50 chars)"
+#USAGE flag "--html" default=#false help="Send body as HTML (Content-Type: text/html)"
 
 set -euo pipefail
 
@@ -83,8 +83,17 @@ fi
 
 # Build attachment MML parts and validate files
 ATTACH_MML=""
-if [ -n "${usage_attach:-}" ]; then
-  while IFS= read -r filepath; do
+ATTACHES=()
+ATTACH_COUNT=0
+while IFS= read -r filepath; do
+  if [ -n "$filepath" ]; then
+    ATTACHES+=("$filepath")
+    ATTACH_COUNT=$((ATTACH_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_attach:-}" | xargs printf '%s\n')
+
+if [ "$ATTACH_COUNT" -gt 0 ]; then
+  for filepath in "${ATTACHES[@]}"; do
     if [[ "$filepath" != /* ]]; then
       filepath="$(cd "$(dirname "$filepath")" && pwd)/$(basename "$filepath")"
     fi
@@ -95,13 +104,23 @@ if [ -n "${usage_attach:-}" ]; then
     ATTACH_MML="${ATTACH_MML}
 <#part filename=\"${filepath}\"><#/part>"
     echo "Attaching: $(basename "$filepath") ($(du -h "$filepath" | cut -f1 | tr -d ' '))"
-  done < <(echo "$usage_attach" | xargs -n1 printf '%s\n')
+  done
 fi
 
 # Build CC header
 CC_HEADER=""
-if [ -n "${usage_cc:-}" ]; then
-  CC_ADDRS=$(echo "$usage_cc" | xargs -n1 printf '%s\n' | paste -sd ',' - | sed 's/,/, /g')
+CC_ADDRS=""
+CCS=()
+CC_COUNT=0
+while IFS= read -r cc; do
+  if [ -n "$cc" ]; then
+    CCS+=("$cc")
+    CC_COUNT=$((CC_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_cc:-}" | xargs printf '%s\n')
+
+if [ "$CC_COUNT" -gt 0 ]; then
+  CC_ADDRS=$(printf '%s\n' "${CCS[@]}" | paste -sd ',' - | sed 's/,/, /g')
   CC_HEADER="Cc: $CC_ADDRS"
 fi
 

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -2,8 +2,8 @@
 #MISE description="Send a GPG-signed email"
 #USAGE arg "<to>" help="Recipient email address"
 #USAGE arg "<subject>" help="Email subject"
-#USAGE arg "[body]" help="Message body (optional, or use -b flag or stdin)"
-#USAGE flag "-b --body <body>" help="Message body (alternative to positional arg)"
+#USAGE arg "[body_arg]" default="" help="Message body (optional, or use -b flag or stdin)"
+#USAGE flag "-b --body <body>" default="" help="Message body (alternative to positional arg)"
 #USAGE flag "-c --cc <cc>" var=#true default="" help="CC recipient (repeatable)"
 #USAGE flag "-a --attach <attach>" var=#true default="" help="File path to attach (repeatable)"
 #USAGE flag "--allow-short" default=#false help="Allow short message bodies (under 50 chars)"
@@ -42,9 +42,16 @@ if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
   exit 1
 fi
 
-# Body from explicit arg (mise maps both positional [body] and -b flag to usage_body).
-# Treat "-" as "read from stdin" (standard Unix convention).
-BODY="${usage_body:-}"
+# Body from positional arg or -b/--body flag. The positional arg is named
+# `body_arg` so it does not collide with the flag's `usage_body`; defaults on
+# both values clear inherited parent `usage_*` env.
+BODY_ARG="${usage_body_arg:-}"
+BODY_FLAG="${usage_body:-}"
+if [ -n "$BODY_ARG" ] && [ -n "$BODY_FLAG" ]; then
+  echo "Error: Provide message body either positionally or with -b/--body, not both"
+  exit 1
+fi
+BODY="${BODY_FLAG:-$BODY_ARG}"
 [ "$BODY" = "-" ] && BODY=""
 
 # If BODY looks like a file path and the file exists, read its contents

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -9,12 +9,12 @@
 #USAGE flag "--allow-short" help="Allow short message bodies (under 50 chars)"
 #USAGE flag "--html" help="Send body as HTML (Content-Type: text/html)"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-TO="${usage_to:-$1}"
-SUBJECT="${usage_subject:-$2}"
+TO="$usage_to"
+SUBJECT="$usage_subject"
 
 if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
   echo "Usage: emails send <to> <subject> [body]"
@@ -44,7 +44,7 @@ fi
 
 # Body from explicit arg (mise maps both positional [body] and -b flag to usage_body).
 # Treat "-" as "read from stdin" (standard Unix convention).
-BODY="${usage_body:-${3:-}}"
+BODY="${usage_body:-}"
 [ "$BODY" = "-" ] && BODY=""
 
 # If BODY looks like a file path and the file exists, read its contents

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -2,9 +2,9 @@
 #MISE description="Setup email (himalaya) for an agent (one-time local setup)"
 #USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
 
-set -e
+set -euo pipefail
 
-AGENT="${1:?Usage: emails setup <agent>}"
+AGENT="$usage_agent"
 EMAIL="${AGENT}@ricon.family"
 DOMAIN="ricon.family"
 MAIL_SERVER="mail.ricon.family"

--- a/.mise/tasks/sizes
+++ b/.mise/tasks/sizes
@@ -3,7 +3,7 @@
 #USAGE flag "-f --folder <folder>" help="Show details for a specific folder only"
 #USAGE flag "--top <n>" help="Number of largest messages to show per folder (default: 5)"
 
-set -e
+set -euo pipefail
 
 FOLDER="${usage_folder:-}"
 TOP="${usage_top:-5}"

--- a/.mise/tasks/sizes
+++ b/.mise/tasks/sizes
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Show per-folder email sizes and largest messages"
-#USAGE flag "-f --folder <folder>" help="Show details for a specific folder only"
-#USAGE flag "--top <n>" help="Number of largest messages/groups to show per folder (default: 5)"
-#USAGE flag "--group-by <field>" help="Group by sender or subject-prefix"
+#USAGE flag "-f --folder <folder>" default="" help="Show details for a specific folder only"
+#USAGE flag "--top <n>" default="5" help="Number of largest messages/groups to show per folder (default: 5)"
+#USAGE flag "--group-by <field>" default="" help="Group by sender or subject-prefix"
 
 set -euo pipefail
 
@@ -230,7 +230,7 @@ for F in "${FOLDERS[@]}"; do
 done
 
 # Show quota if multi-folder
-if [ -z "$usage_folder" ]; then
+if [ -z "$FOLDER" ]; then
   QUOTA_OUTPUT=$({
     sleep 0.3
     echo "a LOGIN ${AGENT}@ricon.family $PASS"
@@ -240,8 +240,7 @@ if [ -z "$usage_folder" ]; then
     echo "c LOGOUT"
   } | openssl s_client -connect mail.ricon.family:993 -quiet 2>/dev/null)
 
-  QUOTA_LINE=$(echo "$QUOTA_OUTPUT" | grep "^\* QUOTA")
-  if [ -n "$QUOTA_LINE" ]; then
+  if QUOTA_LINE=$(echo "$QUOTA_OUTPUT" | grep "^\* QUOTA"); then
     USED_KB=$(echo "$QUOTA_LINE" | grep -oE 'STORAGE [0-9]+ [0-9]+' | awk '{print $2}')
     LIMIT_KB=$(echo "$QUOTA_LINE" | grep -oE 'STORAGE [0-9]+ [0-9]+' | awk '{print $3}')
     USED_MB=$((USED_KB / 1024))

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -2,9 +2,9 @@
 #MISE description="Check email (himalaya) setup status for an agent"
 #USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
 
-set -e
+set -euo pipefail
 
-AGENT="${1:?Usage: emails status <agent>}"
+AGENT="$usage_agent"
 EMAIL="${AGENT}@ricon.family"
 CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
 

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Run all tests"
 
-set -e
+set -euo pipefail
 
 export MISE_CONFIG_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 bats test/

--- a/.mise/tasks/test-integration
+++ b/.mise/tasks/test-integration
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Run integration tests (maildir-backed, no network)"
 
-set -e
+set -euo pipefail
 
 export MISE_CONFIG_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 bats test/integration/

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Wait for new email to arrive"
-#USAGE flag "-f --folder <folder>" help="Folder to watch (default: INBOX)"
-#USAGE flag "-n --count <n>" help="Wait for at least N new messages (default: 1)"
-#USAGE flag "--timeout <duration>" help="Max wait time in seconds (default: 600)"
-#USAGE flag "--interval <seconds>" help="Poll interval in seconds (default: 30)"
-#USAGE arg "[query...]" var=#true help="Optional himalaya query filter (e.g. 'from groups.io')"
+#USAGE flag "-f --folder <folder>" default="INBOX" help="Folder to watch (default: INBOX)"
+#USAGE flag "-n --count <n>" default="1" help="Wait for at least N new messages (default: 1)"
+#USAGE flag "--timeout <duration>" default="600" help="Max wait time in seconds (default: 600)"
+#USAGE flag "--interval <seconds>" default="30" help="Poll interval in seconds (default: 30)"
+#USAGE arg "[query]" var=#true default="" help="Optional himalaya query filter (e.g. 'from groups.io')"
 
 set -euo pipefail
 
@@ -17,14 +17,23 @@ TIMEOUT="${usage_timeout:-600}"
 
 # Parse optional query (variadic args)
 QUERY_ARGS=()
-if [ -n "${usage_query:-}" ]; then
-  read -ra QUERY_ARGS <<< "$usage_query"
-fi
+QUERY_COUNT=0
+while IFS= read -r arg; do
+  if [ -n "$arg" ]; then
+    QUERY_ARGS+=("$arg")
+    QUERY_COUNT=$((QUERY_COUNT + 1))
+  fi
+done < <(printf '%s' "${usage_query:-}" | xargs printf '%s\n')
 
 # Fetch current envelope IDs from the folder
 get_ids() {
-  "$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$FOLDER" --page-size 1000 -o json "${QUERY_ARGS[@]}" 2>/dev/null \
-    | jq -r '.[].id'
+  if [ "$QUERY_COUNT" -gt 0 ]; then
+    "$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$FOLDER" --page-size 1000 -o json "${QUERY_ARGS[@]}" 2>/dev/null \
+      | jq -r '.[].id'
+  else
+    "$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$FOLDER" --page-size 1000 -o json 2>/dev/null \
+      | jq -r '.[].id'
+  fi
 }
 
 debug() { [ "${DEBUG:-}" = "1" ] && echo "[debug] $*" >&2 || true; }

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -6,7 +6,7 @@
 #USAGE flag "--interval <seconds>" help="Poll interval in seconds (default: 30)"
 #USAGE arg "[query...]" var=#true help="Optional himalaya query filter (e.g. 'from groups.io')"
 
-set -e
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Email intro and current status"
 
-set -e
+set -euo pipefail
 
 export RUST_LOG=error
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.4.18"
+
 [settings]
 quiet = true
 task_output = "interleave"

--- a/test/delete.bats
+++ b/test/delete.bats
@@ -21,6 +21,13 @@ setup() {
   [[ "$output" == *"IDs must be numeric"* ]]
 }
 
+@test "delete: ignores inherited usage vars when args are omitted" {
+  usage_ids=42 usage_all=true run emails delete
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
 @test "delete: moves message to Trash by default" {
   run emails delete 42
   [ "$status" -eq 0 ]

--- a/test/export.bats
+++ b/test/export.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# Tests for emails export task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_agent
+  setup_mock_himalaya
+}
+
+@test "export: writes requested message under strict shell" {
+  set_mock_response "raw exported message"
+
+  run emails export 42 -d "$BATS_TEST_TMPDIR/exported"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Exported 1 message(s)"* ]]
+  [ "$(cat "$BATS_TEST_TMPDIR/exported/42.eml")" = "raw exported message" ]
+  assert_himalaya_called "message read -a test-agent -f INBOX 42"
+}
+
+@test "export: counts failed reads under strict shell" {
+  cat > "$MOCK_BIN/himalaya" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "$MOCK_HIMALAYA_CALLS"
+if [ "$1 $2" = "message read" ]; then
+  exit 1
+fi
+MOCK
+  chmod +x "$MOCK_BIN/himalaya"
+
+  run emails export 42 -d "$BATS_TEST_TMPDIR/exported"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Failed: 42"* ]]
+  [[ "$output" == *"Exported 0 message(s)"* ]]
+  [[ "$output" == *"Failed to export 1 message(s)"* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/exported/42.eml" ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -11,7 +11,11 @@ if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
 fi
 
 emails() {
-  cd "$MISE_CONFIG_ROOT" && mise run -q "$@"
+  if [ -z "${CALLER_PWD:-}" ]; then
+    echo "CALLER_PWD not set — wrapper expects tests to set it in setup()" >&2
+    return 1
+  fi
+  cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$CALLER_PWD" mise run -q "$@"
 }
 export -f emails
 
@@ -20,6 +24,7 @@ export -f emails
 setup_agent() {
   export GIT_AUTHOR_EMAIL="test-agent@ricon.family"
   export BATS_AGENT="test-agent"
+  export CALLER_PWD="${CALLER_PWD:-$BATS_TEST_TMPDIR}"
 
   # Create himalaya config in test tmpdir
   export HIMALAYA_CONFIG="$BATS_TEST_TMPDIR/himalaya/config.toml"

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -15,7 +15,11 @@ if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
 fi
 
 emails() {
-  cd "$MISE_CONFIG_ROOT" && mise run -q "$@"
+  if [ -z "${CALLER_PWD:-}" ]; then
+    echo "CALLER_PWD not set — wrapper expects tests to set it in setup()" >&2
+    return 1
+  fi
+  cd "$MISE_CONFIG_ROOT" && CALLER_PWD="$CALLER_PWD" mise run -q "$@"
 }
 export -f emails
 
@@ -25,6 +29,7 @@ setup_maildir() {
   export MAILDIR_ROOT="$BATS_TEST_TMPDIR/maildir"
   export AGENT="test-agent"
   export GIT_AUTHOR_EMAIL="test-agent@ricon.family"
+  export CALLER_PWD="${CALLER_PWD:-$BATS_TEST_TMPDIR}"
 
   # Create maildir folder structure (INBOX, Sent, Trash, Archive)
   for folder in INBOX Sent Trash Archive Drafts; do

--- a/test/reply.bats
+++ b/test/reply.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Tests for emails reply task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_agent
+  setup_mock_himalaya
+}
+
+@test "reply: ignores inherited usage_body when body is omitted" {
+  usage_body="This inherited reply is long enough to pass validation but must not be used" run emails reply 42
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Reply body is required"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "reply: ignores inherited usage_body when only flags are supplied" {
+  usage_body="This inherited reply is long enough to pass validation but must not be used" run emails reply 42 --html
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Reply body is required"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "reply: rejects body supplied positionally and with --body" {
+  run emails reply 42 "positional reply body that is long enough to pass validation" -b "flag reply body that is long enough to pass validation"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"either positionally or with -b/--body"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}

--- a/test/send.bats
+++ b/test/send.bats
@@ -23,6 +23,27 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
+@test "send: ignores inherited usage_body when body is omitted" {
+  usage_body="This inherited body is long enough to pass validation but must not be used" run emails send user@example.com "Subject"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Message body is required"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "send: ignores inherited usage_body when only flags are supplied" {
+  usage_body="This inherited body is long enough to pass validation but must not be used" run emails send user@example.com "Subject" --html
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Message body is required"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "send: rejects body supplied positionally and with --body" {
+  run emails send user@example.com "Subject" "positional body that is long enough to pass validation" -b "flag body that is long enough to pass validation"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"either positionally or with -b/--body"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
 @test "send: rejects short body without --allow-short" {
   run emails send user@example.com "Test Subject" "hi"
   [ "$status" -ne 0 ]

--- a/test/sizes.bats
+++ b/test/sizes.bats
@@ -80,6 +80,15 @@ MOCK
   [[ "$output" != *"[Triangle Therapists]"* ]]
 }
 
+@test "sizes: all-folder default works under set -u" {
+  run emails sizes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INBOX:"* ]]
+  [[ "$output" == *"Sent:"* ]]
+  [[ "$output" == *"Trash:"* ]]
+  [[ "$output" == *"Archive:"* ]]
+}
+
 @test "sizes: can group by subject prefix" {
   run emails sizes -f INBOX --group-by subject-prefix --top 3
   [ "$status" -eq 0 ]


### PR DESCRIPTION
First of a series of PRs from an audit pass against fold's `creating-a-codebase` reading list (see `mise-conventions.md`, `bats-tool-testing.md`). This one handles the mechanical conventions drift. Follows the shape of [chicle#36](https://github.com/KnickKnackLabs/chicle/pull/36).

## Changes

- **`set -euo pipefail`** on all 17 bash tasks (was bare `set -e`). Caught two latent issues:
  - `read:13, inspect:7, reply:14, send:18-19, 41` used `${usage_id:-$1}` / `${usage_to:-$1}` style fallbacks. These are dead code under mise (the `#USAGE arg "<id>"` spec puts the value in `$usage_id` deterministically), and they crash under `set -u` when called with no positional args because `$1` is evaluated unconditionally by the `:-` operator. Removed — now use `$usage_id` directly.
  - `setup:8` and `status:8` used `${1:?Usage: ...}`. Replaced with `$usage_agent` (backed by the existing `#USAGE arg "<agent>"` spec).
  - `delete:17, export:17` referenced `$usage_ids` directly. Mise doesn't set `usage_*` vars when a `var=#true` variadic got zero values, so it's unbound under `set -u`. Defaulted via `${usage_ids:-}` and routed through a local `IDS_RAW` variable.

- **`mise.toml`**: add `min_version = "2026.4.18"` to match the rest of the org.

- **Test helpers**: propagate `CALLER_PWD` per `bats-tool-testing.md`. Both `test/helpers.bash` and `test/integration-helpers.bash` now guard for `CALLER_PWD` in the `emails()` wrapper and set a default in `setup_agent` / `setup_maildir`. No current task uses `CALLER_PWD`, so this is forward-looking — but the wrapper was diverging from real-usage behavior and would have drifted silently.

## Out of scope (coming in follow-up PRs)

- Adding a `.github/workflows/test.yml` CI workflow (there is none today)
- Adopting `KnickKnackLabs/codebase` with `lint:or-true`
- Standardizing variadic-args parsing on the `xargs` pattern (currently split between `xargs` in `reply`/`send` and `read -ra` in `delete`/`export`/`wait`)
- Refactoring `lib/email.sh` (grep-based TOML parser, move `RUST_LOG=error` and agent detection to `[env]`, dedupe the copy in `welcome`)
- Extracting `lib/imap.sh` (the openssl-based IMAP pattern duplicated across `inspect`/`quota`/`sizes`)

## Verification

```
$ mise run test              # 31/31 pass
$ mise run test-integration  # 27/27 pass
```

Total: 58/58, same count as `main`.

Also `grep -rnE 'usage_[a-z]+:\-\$[0-9]|:\?Usage' .mise/tasks/` returns empty, confirming all bare-positional fallbacks are gone.

## Note for `compose` PR (#3)

Will need a rebase after this lands; `.mise/tasks/compose` should pick up the same `set -euo pipefail` + `$usage_*` conventions. Happy to do that as part of the XSS fix commits I owe you on #3.
