### PR TITLE
ci: add test workflow + declare missing himalaya dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: "Tests - ${{ matrix.name }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Ubuntu 24.04"
+            os: ubuntu-24.04
+          - name: "macOS (ARM)"
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v3
+        with:
+          install: true
+
+      - name: Run unit tests
+        run: mise run test
+
+      - name: Run integration tests
+        run: mise run test-integration

--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,4 @@ task_output = "interleave"
 [tools]
 jq = "latest"
 bats = "1.13.0"
+"github:pimalaya/himalaya" = "1.2.0"


### PR DESCRIPTION
Second in the audit series. Closes a real gap: no CI existed before this, so the 58 tests only ran when someone remembered locally. Also fixes an undeclared dependency.

## Commits

### 1. `mise: declare himalaya tool dependency`

Every task in this repo calls `himalaya`, and `setup`'s error text literally says *"Install with: mise install (himalaya is managed by mise)"* — but `mise.toml` never declared it. The repo was relying on `himalaya` being globally installed some other way (brew, a prior `shimmer email:*` setup, etc.). On a fresh machine with only this repo's `mise install`, every command would fail.

Pinned to `1.2.0`, matching the currently-installed version across denmates' machines.

### 2. `ci: add test.yml workflow`

Standard jdx/mise-action setup. Runs both test suites on `push: main` and all PRs. Platform matrix: Ubuntu 24.04 + macOS ARM (matching emails' actual support — no Windows, no PowerShell). Pattern borrowed from `chicle/.github/workflows/test.yml`.

## Relationship to #5

Independent change, different scope. Can merge in either order. If #5 lands first, this PR will still pass CI because it's already on `set -euo pipefail` via the rebase. If this lands first, #5 picks up CI on its next push.

## Verification

Local: `mise run test` → 31/31, `mise run test-integration` → 27/27.
CI: will populate after push — will comment with results.

## Out of scope

- `lint` job — emails doesn't have a `lint` task yet. That comes in the codebase PR (next in the series).
- Caching mise's tool install — not a premature optimization we need here; cold-install is fast for 3 tools.
