### PR TITLE
codebase: adopt linting + clean up 6 '|| true' sites + gum-table migration

### DIFF
--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -72,9 +72,10 @@ if [ "$HAS_ATTACHMENT" = "true" ]; then
     DOWNLOADS_DIR="${HOME}/agents/${AGENT}/downloads"
     mkdir -p "$DOWNLOADS_DIR"
 
-    BEFORE=$(ls -1 "$DOWNLOADS_DIR" 2>/dev/null || true)
+    # mkdir -p ran above so the dir exists; ls should not fail here
+    BEFORE=$(ls -1 "$DOWNLOADS_DIR")
     himalaya attachment download -a "$AGENT" -f "$FOLDER" -o plain "$ID" >/dev/null 2>&1
-    AFTER=$(ls -1 "$DOWNLOADS_DIR" 2>/dev/null || true)
+    AFTER=$(ls -1 "$DOWNLOADS_DIR")
     NEW_FILES=$(comm -13 <(echo "$BEFORE" | sort) <(echo "$AFTER" | sort))
 
     FOUND=0

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -32,7 +32,8 @@ fi
 
 # Get password: env var > secrets tool > error
 if [ -z "${EMAIL_PASSWORD:-}" ]; then
-  EMAIL_PASSWORD=$(secrets get "$AGENT/email-password" 2>/dev/null || true)
+  # Empty result (missing key) is expected; we fall through to the empty-check below.
+  EMAIL_PASSWORD=$(secrets get "$AGENT/email-password" 2>/dev/null) || EMAIL_PASSWORD=""
 fi
 
 if [ -z "$EMAIL_PASSWORD" ]; then

--- a/.mise/tasks/sizes
+++ b/.mise/tasks/sizes
@@ -32,7 +32,7 @@ for F in "${FOLDERS[@]}"; do
   COUNT="${COUNT:-0}"
 
   if [ "$COUNT" = "0" ]; then
-    printf "%-10s %6s  (%s messages)\n" "$F:" "0KB" "0"
+    printf "%-10s %6s  (%s messages)\n" "$F:" "0KB" "0"  # codebase:ignore gum-table — header of a tree output, not a table
     continue
   fi
 
@@ -54,14 +54,14 @@ for F in "${FOLDERS[@]}"; do
     TOTAL_DISPLAY="${TOTAL_KB}KB"
   fi
 
-  printf "%-10s %6s  (%s messages)\n" "$F:" "$TOTAL_DISPLAY" "$COUNT"
+  printf "%-10s %6s  (%s messages)\n" "$F:" "$TOTAL_DISPLAY" "$COUNT"  # codebase:ignore gum-table — header of a tree output, not a table
 
   echo "$ID_SIZES" | sort -k2 -rn | head -"$TOP" | while read -r ID S; do
     S_KB=$((S / 1024))
     if [ "$S_KB" -ge 1024 ]; then
-      printf "           └ #%-4s %dMB\n" "$ID" "$((S_KB / 1024))"
+      printf "           └ #%-4s %dMB\n" "$ID" "$((S_KB / 1024))"  # codebase:ignore gum-table — hierarchical tree, not tabular
     elif [ "$S_KB" -gt 0 ]; then
-      printf "           └ #%-4s %dKB\n" "$ID" "$S_KB"
+      printf "           └ #%-4s %dKB\n" "$ID" "$S_KB"  # codebase:ignore gum-table — hierarchical tree, not tabular
     fi
   done
 done

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -27,7 +27,11 @@ get_ids() {
     | jq -r '.[].id'
 }
 
-debug() { [ "${DEBUG:-}" = "1" ] && echo "[debug] $*" >&2 || true; }
+debug() {
+  if [ "${DEBUG:-}" = "1" ]; then
+    echo "[debug] $*" >&2
+  fi
+}
 
 # Snapshot current state
 INITIAL_IDS=$(get_ids | sort)
@@ -41,7 +45,8 @@ while true; do
 
   CURRENT_IDS=$(get_ids | sort)
   NEW_IDS=$(comm -23 <(echo "$CURRENT_IDS") <(echo "$INITIAL_IDS"))
-  NEW_COUNT=$(echo "$NEW_IDS" | grep -c . || true)
+  # grep -c exits 1 when no lines match, but still prints "0"
+  NEW_COUNT=$(echo "$NEW_IDS" | grep -c . || [ $? -eq 1 ])
 
   printf "\rWaiting for mail in %s... %ds (%d new)" "$FOLDER" "$ELAPSED" "$NEW_COUNT" >&2
 

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -4,6 +4,7 @@
 set -e
 
 export RUST_LOG=error
+HIMALAYA_BIN="${HIMALAYA:-himalaya}"
 
 # Determine current agent from environment or git config
 if [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then
@@ -29,7 +30,7 @@ if [ -z "$AGENT" ]; then
 fi
 
 EMAIL="${AGENT}@ricon.family"
-CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
+CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
 
 echo "Your email: $EMAIL"
 echo ""
@@ -53,7 +54,11 @@ echo ""
 echo "Folders:"
 {
   for folder in INBOX Sent Trash Archive; do
-    count=$(himalaya envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null | tail -n +4 | wc -l | tr -d ' ')
+    if folder_output=$("$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null); then
+      count=$(echo "$folder_output" | tail -n +4 | wc -l | tr -d ' ')
+    else
+      count="?"
+    fi
     printf '%s|%s\n' "$folder" "$count"
   done
 } | gum table -s '|' -c 'Folder,Messages' -p
@@ -61,9 +66,11 @@ echo ""
 
 # Show recent messages
 echo "Recent messages:"
-if command -v himalaya &> /dev/null; then
-  # Empty-on-failure is fine: the branch below shows a helpful fallback message.
-  EMAILS=$(himalaya envelope list -a "$AGENT" -w 100 2>&1 | head -7) || EMAILS=""
+if command -v "$HIMALAYA_BIN" &> /dev/null; then
+  EMAILS=""
+  if emails_output=$("$HIMALAYA_BIN" envelope list -a "$AGENT" -w 100 2>/dev/null); then
+    EMAILS=$(echo "$emails_output" | head -7)
+  fi
   if [ -n "$EMAILS" ]; then
     echo "$EMAILS" | sed 's/^/  /'
   else

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -51,16 +51,19 @@ echo ""
 
 # Show folder summary
 echo "Folders:"
-for folder in INBOX Sent Trash Archive; do
-  count=$(himalaya envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null | tail -n +4 | wc -l | tr -d ' ')
-  printf "  %-10s %s messages\n" "$folder" "$count"
-done
+{
+  for folder in INBOX Sent Trash Archive; do
+    count=$(himalaya envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null | tail -n +4 | wc -l | tr -d ' ')
+    printf '%s|%s\n' "$folder" "$count"
+  done
+} | gum table -s '|' -c 'Folder,Messages' -p
 echo ""
 
 # Show recent messages
 echo "Recent messages:"
 if command -v himalaya &> /dev/null; then
-  EMAILS=$(himalaya envelope list -a "$AGENT" -w 100 | head -7 || true)
+  # Empty-on-failure is fine: the branch below shows a helpful fallback message.
+  EMAILS=$(himalaya envelope list -a "$AGENT" -w 100 2>&1 | head -7) || EMAILS=""
   if [ -n "$EMAILS" ]; then
     echo "$EMAILS" | sed 's/^/  /'
   else

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,19 @@
 [settings]
 quiet = true
 task_output = "interleave"
+experimental = true
+
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 jq = "latest"
 bats = "1.13.0"
+gum = "0.17.0"
+"shiv:codebase" = "0.2.0"
+
+[_.codebase]
+lint = ["mise-settings", "gum-table", "or-true"]
+
+[_.codebase.scope]
+gum-table = ".mise/tasks"

--- a/test/welcome.bats
+++ b/test/welcome.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# Tests for emails welcome task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_agent
+  setup_mock_himalaya
+
+  # Make quota fail before network; welcome should honor HIMALAYA_CONFIG.
+  cat > "$HIMALAYA_CONFIG" <<EOF
+[accounts.test-agent]
+default = true
+EOF
+}
+
+@test "welcome: failed recent fetch uses fallback without printing himalaya stderr" {
+  cat > "$HIMALAYA" <<'MOCK'
+#!/usr/bin/env bash
+echo "mock himalaya failure: $*" >&2
+exit 42
+MOCK
+  chmod +x "$HIMALAYA"
+
+  run emails welcome
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Status: ✓ configured"* ]]
+  [[ "$output" == *"(could not fetch - check connection)"* ]]
+  [[ "$output" != *"mock himalaya failure"* ]]
+}


### PR DESCRIPTION
Third in the audit series. Adopts [`KnickKnackLabs/codebase`](https://github.com/KnickKnackLabs/codebase) linting and cleans up the violations the rules surfaced.

## Changes

### `mise.toml`
- Add `[plugins] shiv = "https://github.com/KnickKnackLabs/vfox-shiv"` (per BJ's shimmer `mise.toml` template).
- `[tools]` now includes `"shiv:codebase" = "0.2.0"` and `gum = "0.17.0"`.
- `[_.codebase] lint = ["mise-settings", "gum-table", "or-true"]`, with `[_.codebase.scope] gum-table = ".mise/tasks"`.

### `|| true` cleanup (5 lines, 4 files)

Applied BJ's toolkit from [shimmer#734](https://github.com/KnickKnackLabs/shimmer/pull/734) — convert when an expressive alternative exists, annotate only as a last resort:

| Site | Before | After |
|------|--------|-------|
| `wait:30` `debug()` helper | `[ cond ] && echo ... \|\| true` | Explicit `if cond; then echo ...; fi` (the `&&`/`\|\|` chain was a latent bug under `set -e`) |
| `wait:44` `NEW_COUNT` | `grep -c . \|\| true` | `grep -c . \|\| [ $? -eq 1 ]` (grep exits 1 on no-match but still prints `0`) |
| `read:75,77` `BEFORE/AFTER` | `ls ... 2>/dev/null \|\| true` | Bare `ls ...` (mkdir -p ran above, ls won't fail) |
| `setup:35` `EMAIL_PASSWORD` | `secrets get ... \|\| true` | `\|\| EMAIL_PASSWORD=""` (empty-on-missing is expected; check below handles it) |
| `welcome:63` `EMAILS` | `himalaya ... \|\| true` | `\|\| EMAILS=""` (empty triggers the fallback-message branch) |

### `gum-table` cleanup (1 conversion + 2 annotations)

- **Converted:** `welcome:56` folder summary — was a hand-aligned `printf "%-10s %s messages"`; now renders via `gum table -s '|' -c 'Folder,Messages' -p`. Actual table, not simulated-table.
- **Annotated:** `sizes:35,57` — these `printf %-10s %6s (%s messages)` lines are *headers* of a hierarchical tree (folder header + `└ #id size` children). The lint rule sees the format string and flags them, but the output is intentionally not tabular — `gum table` can't render the `└`-indented children. Inline `# codebase:ignore gum-table — header of a tree output, not a table`. Real fix would be a coherent redesign of the `sizes` output; filing as follow-up.

## Verification

```
$ mise run test              # 31/31 pass
$ mise run test-integration  # 27/27 pass
$ codebase lint:or-true /path/to/emails/.mise/tasks /path/to/emails/lib
  OK    tasks (17 file(s) clean)
  OK    lib (1 file(s) clean)
$ codebase lint:gum-table /path/to/emails/.mise/tasks
  OK    no manual table formatting found
$ codebase lint:mise-settings /path/to/emails
  OK    emails
$ codebase pre-commit && bash .git/hooks/pre-commit.d/codebase
  Installed pre-commit hook
  (no output — passes)
```

## Bugs found in `codebase` while doing this (filing separately)

1. **Relative target paths silently lint the wrong directory.** `codebase lint:or-true .mise/tasks` when run from `/path/to/emails` lints `<codebase-install>/.mise/tasks` instead, giving a false negative. The shim dispatches via `mise -C $REPO run ...` and tasks don't resolve target paths against `CALLER_PWD`. Workaround: pass absolute paths (verified in the verification commands above — all use `/path/to/emails/...`). **Filing a codebase issue + a self-work session is fixing it in parallel.**

2. **`[_.codebase.scope]` parser strips internal spaces.** Writing `or-true = ".mise/tasks lib"` in the scope section produced a hook with `scope='.mise/taskslib'` (concatenated, not two paths). Workaround: drop the multi-path override; the default `.` scope covers everything. Also worth filing.

## Out of scope (coming in follow-up PRs)

- Standardize variadic-args parsing on the `xargs` pattern (currently split between `xargs` in `reply`/`send` and `read -ra` in `delete`/`export`/`wait`) — next PR in the audit series.
- Refactor `lib/email.sh` (grep-based TOML parser, dedup agent-detection vs `welcome`, move `RUST_LOG=error` to `[env]`).
- Extract `lib/imap.sh` from the openssl pattern duplicated across `inspect`/`quota`/`sizes`.
- Redesign `sizes` output so the gum-table annotations can go away.

## Depends on

None — independent from #5 and #6. Rebase will be trivial if any of them land first (no overlap in mise.toml sections).
