### PR TITLE
Fix grouped size diagnostics regressions

### DIFF
--- a/.mise/tasks/sizes
+++ b/.mise/tasks/sizes
@@ -71,11 +71,12 @@ extract_id_sizes() {
 
 show_grouped_sizes() {
   local group_by="$1"
+  local top="$2"
   local input_file
   input_file=$(mktemp)
   cat > "$input_file"
 
-  if ! python3 - "$group_by" "$input_file" <<'PY'
+  if ! python3 - "$group_by" "$input_file" "$top" <<'PY'
 import email.header
 import email.utils
 import re
@@ -83,6 +84,7 @@ import sys
 
 mode = sys.argv[1]
 input_file = sys.argv[2]
+top = int(sys.argv[3])
 
 
 def decode_mime(value):
@@ -95,28 +97,42 @@ def decode_mime(value):
         return value
 
 
-def sender_label(value):
-    decoded = decode_mime(value)
-    name, addr = email.utils.parseaddr(decoded)
-    return (addr or name or decoded or "(unknown sender)").lower()
-
-
-def subject_prefix(value):
-    subject = decode_mime(value)
-    match = re.match(r"\s*(\[[^\]]+\])", subject)
-    if match:
-        return match.group(1)
-    match = re.match(r"\s*([^:]{1,60}:)", subject)
-    if match:
-        return match.group(1).strip()
-    words = subject.split()
-    if not words:
-        return "(no subject)"
-    return " ".join(words[:6])
-
-
 def clean_label(value):
     return re.sub(r"\s+", " ", value).strip()
+
+
+def sender_group(value):
+    decoded = decode_mime(value)
+    name, addr = email.utils.parseaddr(decoded)
+    label = (addr or name or decoded or "(unknown sender)").lower()
+    return label, label
+
+
+def strip_reply_markers(subject):
+    marker = re.compile(r"^\s*(?:(?:re|fw|fwd)\s*:\s*)", re.I)
+    previous = None
+    while subject != previous:
+        previous = subject
+        subject = marker.sub("", subject, count=1)
+    return subject
+
+
+def subject_prefix_group(value):
+    subject = strip_reply_markers(decode_mime(value))
+    match = re.match(r"\s*(\[[^\]]+\])", subject)
+    if match:
+        label = match.group(1)
+        return label, label.casefold()
+    match = re.match(r"\s*([^:]{1,60}:)", subject)
+    if match:
+        label = match.group(1).strip()
+        return label, label.casefold()
+    words = subject.split()
+    if not words:
+        label = "(no subject)"
+    else:
+        label = " ".join(words[:6])
+    return label, label.casefold()
 
 
 groups = {}
@@ -131,13 +147,12 @@ def finish_current():
         return
     uid, size = current
     if mode == "sender":
-        label = sender_label(headers.get("from", ""))
+        label, key = sender_group(headers.get("from", ""))
     else:
-        label = subject_prefix(headers.get("subject", ""))
-    label = clean_label(label)
-    if not label:
-        label = "(unknown)"
-    entry = groups.setdefault(label, {"count": 0, "size": 0})
+        label, key = subject_prefix_group(headers.get("subject", ""))
+    label = clean_label(label) or "(unknown)"
+    key = clean_label(key) or label.casefold()
+    entry = groups.setdefault(key, {"label": label, "count": 0, "size": 0})
     entry["count"] += 1
     entry["size"] += size
     current = None
@@ -174,8 +189,8 @@ with open(input_file, encoding="utf-8", errors="replace") as handle:
 
 finish_current()
 
-for label, data in sorted(groups.items(), key=lambda item: (-item[1]["size"], item[0])):
-    print(f"{data['size']}\t{data['count']}\t{label}")
+for data in sorted(groups.values(), key=lambda item: (-item["size"], item["label"]))[:top]:
+    print(f"{data['size']}\t{data['count']}\t{data['label']}")
 PY
   then
     rm -f "$input_file"
@@ -202,7 +217,7 @@ for F in "${FOLDERS[@]}"; do
   printf "%-10s %6s  (%s messages)\n" "$F:" "$TOTAL_DISPLAY" "$COUNT"
 
   if [ -n "$GROUP_BY" ]; then
-    echo "$RESULT" | show_grouped_sizes "$GROUP_BY" | head -"$TOP" | while IFS=$'\t' read -r S GROUP_COUNT LABEL; do
+    echo "$RESULT" | show_grouped_sizes "$GROUP_BY" "$TOP" | while IFS=$'\t' read -r S GROUP_COUNT LABEL; do
       [ -z "$S" ] && continue
       printf "           └ %-6s %4s  %s\n" "$(format_size "$S")" "$GROUP_COUNT" "$LABEL"
     done

--- a/test/sizes.bats
+++ b/test/sizes.bats
@@ -16,23 +16,52 @@ setup_mock_openssl() {
   cat > "$MOCK_BIN/openssl" <<'MOCK'
 #!/usr/bin/env bash
 cat >/dev/null
+
+if [ "${MOCK_OPENSSL_SCENARIO:-}" = "many-groups" ]; then
+  echo '* 100 EXISTS'
+  for i in $(seq 1 100); do
+    echo "* $i FETCH (UID $i RFC822.SIZE 1024 BODY[HEADER.FIELDS (FROM SUBJECT)] {80}"
+    echo "From: Sender $i <sender$i@example.com>"
+    echo "Subject: Topic $i"
+    echo ')'
+  done
+  echo 'a OK SELECT completed'
+  exit 0
+fi
+
 cat <<'EOF'
-* 4 EXISTS
+* 8 EXISTS
 * 1 FETCH (UID 101 RFC822.SIZE 10485760 BODY[HEADER.FIELDS (FROM SUBJECT)] {112}
 From: "Alice via groups.io" <alice=gmail.com@groups.io>
 Subject: [Triangle Therapists] Office sublet with photos
 )
-* 2 FETCH (UID 102 RFC822.SIZE 5242880 BODY[HEADER.FIELDS (FROM SUBJECT)] {106}
+* 2 FETCH (UID 102 RFC822.SIZE 5242880 BODY[HEADER.FIELDS (FROM SUBJECT)] {110}
 From: "Bob via groups.io" <bob=gmail.com@groups.io>
-Subject: [Triangle Therapists] Another office listing
+Subject: Re: [Triangle Therapists] Another office listing
 )
-* 3 FETCH (UID 103 RFC822.SIZE 102400 BODY[HEADER.FIELDS (FROM SUBJECT)] {86}
-From: Melissa Cramer <melissa@growheallove.com>
-Subject: Website feedback
+* 3 FETCH (UID 103 RFC822.SIZE 1048576 BODY[HEADER.FIELDS (FROM SUBJECT)] {112}
+From: "Carol via groups.io" <carol=gmail.com@groups.io>
+Subject: Fwd: Re: [Triangle Therapists] Forwarded listing
 )
-* 4 FETCH (UID 104 RFC822.SIZE 204800 BODY[HEADER.FIELDS (FROM SUBJECT)] {83}
+* 4 FETCH (UID 104 RFC822.SIZE 204800 BODY[HEADER.FIELDS (FROM SUBJECT)] {88}
+From: Agent <agent@ricon.family>
+Subject: Session: Morning report
+)
+* 5 FETCH (UID 105 RFC822.SIZE 102400 BODY[HEADER.FIELDS (FROM SUBJECT)] {88}
+From: Agent <agent@ricon.family>
+Subject: session: Evening report
+)
+* 6 FETCH (UID 106 RFC822.SIZE 307200 BODY[HEADER.FIELDS (FROM SUBJECT)] {84}
+From: GitHub <notifications@github.com>
+Subject: FW: [GitHub] Review requested
+)
+* 7 FETCH (UID 107 RFC822.SIZE 204800 BODY[HEADER.FIELDS (FROM SUBJECT)] {83}
 From: Mercury <notifications@mercury.com>
 Subject: Invite reminder
+)
+* 8 FETCH (UID 108 RFC822.SIZE 102400 BODY[HEADER.FIELDS (FROM SUBJECT)] {86}
+From: Melissa Cramer <melissa@growheallove.com>
+Subject: Website feedback
 )
 a OK SELECT completed
 EOF
@@ -52,19 +81,35 @@ MOCK
 }
 
 @test "sizes: can group by subject prefix" {
-  run emails sizes -f INBOX --group-by subject-prefix --top 2
+  run emails sizes -f INBOX --group-by subject-prefix --top 3
   [ "$status" -eq 0 ]
-  [[ "$output" == *"15MB"* ]]
-  [[ "$output" == *"   2  [Triangle Therapists]"* ]]
-  [[ "$output" == *"Invite reminder"* ]]
+  [[ "$output" == *"16MB"* ]]
+  [[ "$output" == *"   3  [Triangle Therapists]"* ]]
+  [[ "$output" == *"[GitHub]"* ]]
+  [[ "$output" != *"Re:"* ]]
+  [[ "$output" != *"Fwd:"* ]]
+}
+
+@test "sizes: normalizes subject-prefix case without changing display spelling" {
+  run emails sizes -f INBOX --group-by subject-prefix --top 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"   2  Session:"* ]]
+  [[ "$output" != *"session:"* ]]
 }
 
 @test "sizes: can group by sender" {
-  run emails sizes -f INBOX --group-by sender --top 3
+  run emails sizes -f INBOX --group-by sender --top 4
   [ "$status" -eq 0 ]
   [[ "$output" == *"alice=gmail.com@groups.io"* ]]
   [[ "$output" == *"bob=gmail.com@groups.io"* ]]
-  [[ "$output" == *"notifications@mercury.com"* ]]
+  [[ "$output" == *"agent@ricon.family"* ]]
+}
+
+@test "sizes: truncates grouped output without BrokenPipeError" {
+  MOCK_OPENSSL_SCENARIO=many-groups run emails sizes -f INBOX --group-by sender --top 3
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"BrokenPipeError"* ]]
+  [ "$(printf '%s\n' "$output" | grep -c '^           └')" -eq 3 ]
 }
 
 @test "sizes: rejects unsupported group fields" {


### PR DESCRIPTION
## Summary
- Strip repeated leading reply/forward markers before subject-prefix grouping
- Group subject prefixes case-insensitively without title-casing display labels
- Move grouped --top truncation inside Python to avoid BrokenPipeError from piping into head
- Add BATS coverage for reply/forward prefixes, case normalization, and many-group truncation

Fixes #11
Fixes #12

## Verification
- bash -n .mise/tasks/sizes
- mise run test
- mise run test-integration
- git diff --check
- mise x shellcheck@0.11.0 -- shellcheck -x .mise/tasks/sizes
- live smoke: mise run sizes -f INBOX --group-by subject-prefix --top 8