### PR TITLE
fix: keep welcome fallback isolated

### DIFF
--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -4,6 +4,7 @@
 set -e
 
 export RUST_LOG=error
+HIMALAYA_BIN="${HIMALAYA:-himalaya}"
 
 # Determine current agent from environment or git config
 if [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then
@@ -29,7 +30,7 @@ if [ -z "$AGENT" ]; then
 fi
 
 EMAIL="${AGENT}@ricon.family"
-CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
+CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
 
 echo "Your email: $EMAIL"
 echo ""
@@ -53,7 +54,11 @@ echo ""
 echo "Folders:"
 {
   for folder in INBOX Sent Trash Archive; do
-    count=$(himalaya envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null | tail -n +4 | wc -l | tr -d ' ')
+    if folder_output=$("$HIMALAYA_BIN" envelope list -a "$AGENT" -f "$folder" --page-size 1000 2>/dev/null); then
+      count=$(echo "$folder_output" | tail -n +4 | wc -l | tr -d ' ')
+    else
+      count="?"
+    fi
     printf '%s|%s\n' "$folder" "$count"
   done
 } | gum table -s '|' -c 'Folder,Messages' -p
@@ -61,9 +66,11 @@ echo ""
 
 # Show recent messages
 echo "Recent messages:"
-if command -v himalaya &> /dev/null; then
-  # Empty-on-failure is fine: the branch below shows a helpful fallback message.
-  EMAILS=$(himalaya envelope list -a "$AGENT" -w 100 2>&1 | head -7) || EMAILS=""
+if command -v "$HIMALAYA_BIN" &> /dev/null; then
+  EMAILS=""
+  if emails_output=$("$HIMALAYA_BIN" envelope list -a "$AGENT" -w 100 2>/dev/null); then
+    EMAILS=$(echo "$emails_output" | head -7)
+  fi
   if [ -n "$EMAILS" ]; then
     echo "$EMAILS" | sed 's/^/  /'
   else

--- a/test/welcome.bats
+++ b/test/welcome.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# Tests for emails welcome task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_agent
+  setup_mock_himalaya
+
+  # Make quota fail before network; welcome should honor HIMALAYA_CONFIG.
+  cat > "$HIMALAYA_CONFIG" <<EOF
+[accounts.test-agent]
+default = true
+EOF
+}
+
+@test "welcome: failed recent fetch uses fallback without printing himalaya stderr" {
+  cat > "$HIMALAYA" <<'MOCK'
+#!/usr/bin/env bash
+echo "mock himalaya failure: $*" >&2
+exit 42
+MOCK
+  chmod +x "$HIMALAYA"
+
+  run emails welcome
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Status: ✓ configured"* ]]
+  [[ "$output" == *"(could not fetch - check connection)"* ]]
+  [[ "$output" != *"mock himalaya failure"* ]]
+}


### PR DESCRIPTION
Fix-it for #7.

The reviewed branch removes `|| true` from `emails welcome`, but the replacement still treats a failing `himalaya ... | head` pipeline as success and prints stderr as if it were recent email output. This keeps welcome isolated/testable by honoring `HIMALAYA`/`HIMALAYA_CONFIG`, preserves the fallback on recent-fetch failure, and adds a regression that uses a failing mock himalaya instead of real email state.

Verification:
- `bash -n .mise/tasks/welcome test/welcome.bats`
- `MISE_AUTO_INSTALL=0 mise run test`
- `MISE_AUTO_INSTALL=0 mise run test-integration`
- `bun test src/`
- `MISE_AUTO_INSTALL=0 mise exec -- codebase lint "$PWD"`
- `git diff --check origin/codebase-adopt...HEAD`
