### PR TITLE
test: assert wait query argv boundaries

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -60,12 +60,22 @@ setup_mock_himalaya() {
 
   # Track calls for assertions
   export MOCK_HIMALAYA_CALLS="$BATS_TEST_TMPDIR/himalaya-calls.log"
+  export MOCK_HIMALAYA_ARGV_CALLS="$BATS_TEST_TMPDIR/himalaya-argv-calls.log"
   : > "$MOCK_HIMALAYA_CALLS"
+  : > "$MOCK_HIMALAYA_ARGV_CALLS"
 
   cat > "$MOCK_BIN/himalaya" <<'MOCK'
 #!/usr/bin/env bash
-# Log the call
+# Log the call (space-joined for existing substring assertions, and
+# length-prefixed argv for tests that need argument-boundary checks).
 echo "$@" >> "$MOCK_HIMALAYA_CALLS"
+{
+  printf 'argc=%s' "$#"
+  for arg in "$@"; do
+    printf '\t%s:%s' "${#arg}" "$arg"
+  done
+  printf '\n'
+} >> "$MOCK_HIMALAYA_ARGV_CALLS"
 
 # Read canned response if set
 if [ -n "${MOCK_HIMALAYA_RESPONSE:-}" ] && [ -f "$MOCK_HIMALAYA_RESPONSE" ]; then

--- a/test/wait.bats
+++ b/test/wait.bats
@@ -28,16 +28,27 @@ setup() {
 @test "wait: quoted multi-word --query is passed as a single himalaya arg" {
   usage_timeout=1 usage_interval=1 run emails wait "from groups.io"
   [ "$status" -eq 0 ]
-  # The mock logs each invocation's args, space-joined, on its own line.
-  # 'from groups.io' should appear together as one phrase — not split by a
-  # newline (which would mean read -ra fragmented it into two args).
-  run cat "$MOCK_HIMALAYA_CALLS"
-  [[ "$output" == *"from groups.io"* ]]
+  # The argv log records argument boundaries as length-prefixed fields. The
+  # query must be one 14-byte arg, not two args (`from` + `groups.io`).
+  run cat "$MOCK_HIMALAYA_ARGV_CALLS"
+  [[ "$output" == *"argc=11"* ]]
+  [[ "$output" == *$'\t14:from groups.io'* ]]
+  [[ "$output" != *$'\t4:from\t9:groups.io'* ]]
+}
+
+@test "wait: multiple query args preserve quotes and metacharacters literally" {
+  usage_timeout=1 usage_interval=1 run emails wait "from groups.io" 'subject "hello";rm'
+  [ "$status" -eq 0 ]
+  run cat "$MOCK_HIMALAYA_ARGV_CALLS"
+  [[ "$output" == *"argc=12"* ]]
+  [[ "$output" == *$'\t14:from groups.io'* ]]
+  [[ "$output" == *$'\t18:subject "hello";rm'* ]]
 }
 
 @test "wait: empty --query omits query args from himalaya call" {
   usage_timeout=1 usage_interval=1 run emails wait
   [ "$status" -eq 0 ]
-  run grep -c "from " "$MOCK_HIMALAYA_CALLS"
-  [ "$output" = "0" ]
+  run cat "$MOCK_HIMALAYA_ARGV_CALLS"
+  [[ "$output" == *"argc=10"* ]]
+  [[ "$output" != *$'\t0:'* ]]
 }


### PR DESCRIPTION
Fix-it for #8.

The current wait regression test logs mock himalaya calls with `echo "$@"`, so a single query arg (`"from groups.io"`) and two split args (`from` + `groups.io`) both serialize as the same `from groups.io` string. This adds a parallel length-prefixed argv log to the mock and tightens `wait` tests to assert argument boundaries, plus quotes/metacharacter coverage.

Verification:
- `bats test/wait.bats test/list.bats test/delete.bats test/send.bats test/lib.bats` (34/34)
- `MISE_AUTO_INSTALL=0 mise run test` (56/56)
- `MISE_AUTO_INSTALL=0 mise run test-integration` (27/27)
- `bun test src/` (38/38)
- `git diff --check origin/variadic-xargs...HEAD`
- `bash -n .mise/tasks/*`
