### PR TITLE
fix(export): avoid strict-shell counter aborts

### DIFF
--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -61,11 +61,11 @@ EXPORTED=0
 FAILED=0
 for ID in "${IDS[@]}"; do
   if "$HIMALAYA_BIN" message read -a "$AGENT" -f "$FOLDER" "$ID" > "$DEST/$ID.eml" 2>/dev/null; then
-    ((EXPORTED++))
+    EXPORTED=$((EXPORTED + 1))
   else
     echo "  Failed: $ID"
     rm -f "$DEST/$ID.eml"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
   fi
 done
 

--- a/test/export.bats
+++ b/test/export.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# Tests for emails export task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_agent
+  setup_mock_himalaya
+}
+
+@test "export: writes requested message under strict shell" {
+  set_mock_response "raw exported message"
+
+  run emails export 42 -d "$BATS_TEST_TMPDIR/exported"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Exported 1 message(s)"* ]]
+  [ "$(cat "$BATS_TEST_TMPDIR/exported/42.eml")" = "raw exported message" ]
+  assert_himalaya_called "message read -a test-agent -f INBOX 42"
+}
+
+@test "export: counts failed reads under strict shell" {
+  cat > "$MOCK_BIN/himalaya" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "$MOCK_HIMALAYA_CALLS"
+if [ "$1 $2" = "message read" ]; then
+  exit 1
+fi
+MOCK
+  chmod +x "$MOCK_BIN/himalaya"
+
+  run emails export 42 -d "$BATS_TEST_TMPDIR/exported"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Failed: 42"* ]]
+  [[ "$output" == *"Exported 0 message(s)"* ]]
+  [[ "$output" == *"Failed to export 1 message(s)"* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/exported/42.eml" ]
+}


### PR DESCRIPTION
## Summary
- replace post-increment arithmetic in `emails export` with assignment-form increments so `set -e` does not abort on the first success/failure
- add export unit coverage for successful and failed message reads under strict shell

## Why
`((EXPORTED++))` and `((FAILED++))` evaluate to the old counter value. When the old value is `0`, Bash returns status 1, and `set -e` exits the task before the final export summary.

## Verification
- `bash -n .mise/tasks/export test/export.bats`
- `MISE_AUTO_INSTALL=0 bats --print-output-on-failure test/export.bats`
- `find .mise/tasks -maxdepth 1 -type f -perm -111 -print0 | xargs -0 bash -n`
- `git diff --check origin/conventions-pass...HEAD`
- `MISE_AUTO_INSTALL=0 mise run test` (63/63)
- `MISE_AUTO_INSTALL=0 mise run test-integration` (27/27)
- `bun test src/` (38/38)
