### PR TITLE
test(send): regression tests for flags-before-positionals stdin body

### DIFF
--- a/test/send.bats
+++ b/test/send.bats
@@ -37,6 +37,13 @@ setup() {
   [ ! -s "$MOCK_HIMALAYA_CALLS" ]
 }
 
+@test "send: ignores inherited usage_body_arg when body is omitted" {
+  usage_body_arg="This inherited body_arg is long enough to pass validation but must not be used" run emails send user@example.com "Subject"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Message body is required"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
 @test "send: rejects body supplied positionally and with --body" {
   run emails send user@example.com "Subject" "positional body that is long enough to pass validation" -b "flag body that is long enough to pass validation"
   [ "$status" -ne 0 ]
@@ -105,6 +112,15 @@ setup() {
   local body="This is a message body piped via stdin that is definitely longer than fifty characters."
   run bash -c "cd '$REPO_DIR' && echo '$body' | GIT_AUTHOR_EMAIL='test-agent@ricon.family' HIMALAYA_CONFIG='$HIMALAYA_CONFIG' HIMALAYA='$HIMALAYA' PATH='$PATH' mise run -q send user@example.com 'Subject'"
   [ "$status" -eq 0 ]
+}
+
+@test "send: --html flag before positionals reads body from stdin" {
+  local body="This is an HTML body piped via stdin that is definitely longer than fifty characters."
+  run bash -c "cd '$REPO_DIR' && echo '$body' | GIT_AUTHOR_EMAIL='test-agent@ricon.family' HIMALAYA_CONFIG='$HIMALAYA_CONFIG' HIMALAYA='$HIMALAYA' PATH='$PATH' mise run -q send --html user@example.com 'Subject'"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"too short"* ]]
+  [[ "$output" != *"body is required"* ]]
+  assert_himalaya_called "template send"
 }
 
 # ============================================================================


### PR DESCRIPTION
Closes #16

## Summary

- The raw `$3` fallback that caused the bug was already removed in `ad54407`; this PR adds the missing regression tests so the fix is locked in.
- Two new tests in `test/send.bats`:
  - `send: --html flag before positionals reads body from stdin` — reproduces the exact invocation from the issue report; the 50-char short-body guard acts as the canary (subject = 7 chars → would fail if subject were mistakenly used as body)
  - `send: ignores inherited usage_body_arg when body is omitted` — mirrors the existing `usage_body` inherited-env guard, now also covering the positional variant

## Test plan

- [ ] `mise run test` — all 69 tests pass
- [ ] New test 55 (`--html before positionals`) directly exercises the broken invocation from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)