### PR TITLE
fix(read): warn when GPG signer differs from message sender

### DIFF
--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -28,7 +28,14 @@ if "$HIMALAYA_BIN" message export --full -a "$AGENT" -f "$FOLDER" -d "$TMPDIR/ms
 
   if [ $GPG_EXIT -eq 0 ] && echo "$GPG_OUTPUT" | grep -q "Good signature"; then
     SIGNER=$(echo "$GPG_OUTPUT" | grep "Good signature from" | sed 's/.*Good signature from "\(.*\)".*/\1/')
-    SIG_TAG="(✓ Signed by ${SIGNER})"
+    SIGNER_EMAIL=$(echo "$SIGNER" | grep -oE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' | head -1)
+    FROM_HEADER=$(grep -m1 -i "^From:" "$TMPDIR/msg.eml" 2>/dev/null || true)
+    FROM_EMAIL=$(echo "$FROM_HEADER" | grep -oE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' | head -1)
+    if [ -n "$SIGNER_EMAIL" ] && [ -n "$FROM_EMAIL" ] && [ "$SIGNER_EMAIL" != "$FROM_EMAIL" ]; then
+      SIG_TAG="(⚠ Signed by ${SIGNER} — sender mismatch)"
+    else
+      SIG_TAG="(✓ Signed by ${SIGNER})"
+    fi
   elif echo "$GPG_OUTPUT" | grep -q "BAD signature"; then
     SIG_TAG="(✗ Bad signature)"
   elif echo "$GPG_OUTPUT" | grep -q "no valid OpenPGP data"; then

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -23,14 +23,25 @@ SIG_TAG=""
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
+extract_email() {
+  local text="$1"
+  local email
+  if email=$(printf '%s\n' "$text" | grep -oE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' | head -1); then
+    printf '%s\n' "$email" | tr '[:upper:]' '[:lower:]'
+  fi
+}
+
 if "$HIMALAYA_BIN" message export --full -a "$AGENT" -f "$FOLDER" -d "$TMPDIR/msg.eml" "$ID" >/dev/null 2>&1; then
   GPG_OUTPUT=$(gpg --verify "$TMPDIR/msg.eml" 2>&1) && GPG_EXIT=0 || GPG_EXIT=$?
 
-  if [ $GPG_EXIT -eq 0 ] && echo "$GPG_OUTPUT" | grep -q "Good signature"; then
+  if [ "$GPG_EXIT" -eq 0 ] && echo "$GPG_OUTPUT" | grep -q "Good signature"; then
     SIGNER=$(echo "$GPG_OUTPUT" | grep "Good signature from" | sed 's/.*Good signature from "\(.*\)".*/\1/')
-    SIGNER_EMAIL=$(echo "$SIGNER" | grep -oE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' | head -1)
-    FROM_HEADER=$(grep -m1 -i "^From:" "$TMPDIR/msg.eml" 2>/dev/null || true)
-    FROM_EMAIL=$(echo "$FROM_HEADER" | grep -oE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' | head -1)
+    SIGNER_EMAIL=$(extract_email "$SIGNER")
+    FROM_HEADER=""
+    if ! FROM_HEADER=$(grep -m1 -i "^From:" "$TMPDIR/msg.eml" 2>/dev/null); then
+      FROM_HEADER=""
+    fi
+    FROM_EMAIL=$(extract_email "$FROM_HEADER")
     if [ -n "$SIGNER_EMAIL" ] && [ -n "$FROM_EMAIL" ] && [ "$SIGNER_EMAIL" != "$FROM_EMAIL" ]; then
       SIG_TAG="(⚠ Signed by ${SIGNER} — sender mismatch)"
     else

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -120,6 +120,26 @@ maildir_count() {
   echo "$count"
 }
 
+# Create a mock gpg binary that returns canned output.
+# Write the desired gpg stderr output to $GPG_MOCK_RESPONSE_FILE before calling emails read.
+# If $GPG_MOCK_RESPONSE_FILE is absent or empty, the mock exits 2 (no OpenPGP data).
+setup_mock_gpg() {
+  local mock_bin="$BATS_TEST_TMPDIR/mock-bin"
+  mkdir -p "$mock_bin"
+  export GPG_MOCK_RESPONSE_FILE="$BATS_TEST_TMPDIR/gpg-mock-response"
+  cat > "$mock_bin/gpg" << 'MOCK'
+#!/usr/bin/env bash
+if [ -f "$GPG_MOCK_RESPONSE_FILE" ] && [ -s "$GPG_MOCK_RESPONSE_FILE" ]; then
+  cat "$GPG_MOCK_RESPONSE_FILE" >&2
+  exit 0
+fi
+echo "gpg: no valid OpenPGP data found" >&2
+exit 2
+MOCK
+  chmod +x "$mock_bin/gpg"
+  export PATH="$mock_bin:$PATH"
+}
+
 # Get the envelope ID of the most recent message via himalaya
 latest_envelope_id() {
   local folder="${1:-INBOX}"

--- a/test/integration/read.bats
+++ b/test/integration/read.bats
@@ -51,3 +51,36 @@ setup() {
   # Output should contain the error or be mostly empty (no message content)
   [[ "$output" != *"Subject:"* ]]
 }
+
+@test "read: matching signer and sender shows checkmark" {
+  setup_mock_gpg
+  echo 'gpg: Good signature from "Test Agent <test-agent@ricon.family>" [ultimate]' > "$GPG_MOCK_RESPONSE_FILE"
+
+  deposit_message --from "test-agent@ricon.family" --subject "Signed by sender"
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Signed by"* ]]
+  [[ "$output" != *"sender mismatch"* ]]
+}
+
+@test "read: signer differs from sender shows mismatch warning" {
+  setup_mock_gpg
+  echo 'gpg: Good signature from "zeke <zeke@ricon.family>" [ultimate]' > "$GPG_MOCK_RESPONSE_FILE"
+
+  deposit_message --from "quick@ricon.family" --subject "Signed by wrong identity"
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠ Signed by"* ]]
+  [[ "$output" == *"sender mismatch"* ]]
+  [[ "$output" != *"✓ Signed by"* ]]
+}

--- a/test/integration/read.bats
+++ b/test/integration/read.bats
@@ -84,3 +84,51 @@ setup() {
   [[ "$output" == *"sender mismatch"* ]]
   [[ "$output" != *"✓ Signed by"* ]]
 }
+
+@test "read: signer without parseable email does not abort" {
+  setup_mock_gpg
+  echo 'gpg: Good signature from "Agent Without Email" [ultimate]' > "$GPG_MOCK_RESPONSE_FILE"
+
+  deposit_message --from "quick@ricon.family" --subject "Signed without email"
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Signed by Agent Without Email"* ]]
+  [[ "$output" != *"sender mismatch"* ]]
+}
+
+@test "read: sender without parseable email does not abort" {
+  setup_mock_gpg
+  echo 'gpg: Good signature from "Zeke <zeke@ricon.family>" [ultimate]' > "$GPG_MOCK_RESPONSE_FILE"
+
+  deposit_message --from "Zeke" --subject "Sender without email"
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Signed by Zeke <zeke@ricon.family>"* ]]
+  [[ "$output" != *"sender mismatch"* ]]
+}
+
+@test "read: signer and sender email comparison is case-insensitive" {
+  setup_mock_gpg
+  echo 'gpg: Good signature from "Quick <QUICK@RICON.FAMILY>" [ultimate]' > "$GPG_MOCK_RESPONSE_FILE"
+
+  deposit_message --from "quick@ricon.family" --subject "Case-insensitive signer"
+
+  local id
+  id=$(latest_envelope_id)
+  [ -n "$id" ] || skip "could not get envelope ID"
+
+  run emails read "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Signed by"* ]]
+  [[ "$output" != *"sender mismatch"* ]]
+}


### PR DESCRIPTION
Closes #18

## Summary

- `emails read` could show `(✓ Signed by zeke <zeke@ricon.family>)` on messages visibly from `quick@` or `johnson@`, which made a valid signature look like sender authentication even when the signer differed from the visible sender.
- `emails read` now compares the signer email from GPG output against the `From:` header email from the exported `.eml`.
- Matching signer/sender continues to show the normal `✓ Signed by ...` tag.
- Mismatched signer/sender shows `⚠ Signed by ... — sender mismatch`.
- Missing/unparseable signer or sender email does not abort under `set -euo pipefail`; it falls back to the normal signed tag instead of making an unsupported mismatch claim.

## Changes

| File | What changed |
|---|---|
| `.mise/tasks/read` | Extract signer and From emails safely; compare case-insensitively; show warning on mismatch |
| `test/integration-helpers.bash` | Add `setup_mock_gpg()` helper for canned GPG verification output |
| `test/integration/read.bats` | Integration coverage for matching signer, mismatched signer, missing parseable emails, and case-insensitive comparison |

## Test plan

Validated locally by merging this branch into current `origin/main` and running:

- [x] `bash -n .mise/tasks/read test/integration-helpers.bash test/integration/read.bats`
- [x] `mise run test-integration --filter 'read:'` — 35/35 passing
- [x] `mise run test` — 79/79 passing
- [x] `mise run test-integration` — 35/35 passing
- [x] configured codebase lints passed: `mise-settings`, `gum-table`, `or-true`
- [x] changed-file `codebase lint:shellcheck` passed for read/integration helper surfaces
- [x] `git diff --check origin/main...HEAD`
