### PR TITLE
feat(send): explicit flags, GHL safety check, and --file structured input

### DIFF
--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 #MISE description="Send a GPG-signed email"
-#USAGE arg "<to>" help="Recipient email address"
-#USAGE arg "<subject>" help="Email subject"
+#USAGE arg "[to_arg]" default="" help="Recipient email address (or use --to)"
+#USAGE arg "[subject_arg]" default="" help="Email subject (or use --subject)"
 #USAGE arg "[body_arg]" default="" help="Message body (optional, or use -b flag or stdin)"
+#USAGE flag "--to <to>" default="" help="Recipient email address (preferred over positional)"
+#USAGE flag "--subject <subject>" default="" help="Email subject (preferred over positional)"
 #USAGE flag "-b --body <body>" default="" help="Message body (alternative to positional arg)"
+#USAGE flag "--file <file>" default="" help="JSON file with to/subject/body/cc fields"
 #USAGE flag "-c --cc <cc>" var=#true default="" help="CC recipient (repeatable)"
 #USAGE flag "-a --attach <attach>" var=#true default="" help="File path to attach (repeatable)"
 #USAGE flag "--allow-short" default=#false help="Allow short message bodies (under 50 chars)"
@@ -13,45 +16,73 @@ set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-TO="$usage_to"
-SUBJECT="$usage_subject"
+# Resolve TO and SUBJECT: explicit flags override positional args
+TO="${usage_to:-${usage_to_arg:-}}"
+SUBJECT="${usage_subject:-${usage_subject_arg:-}}"
+
+# --file: load TO/SUBJECT/BODY/CC from a JSON spec
+FILE_BODY=""
+FILE_CC_LINES=""
+if [ -n "${usage_file:-}" ]; then
+  if [ ! -f "$usage_file" ]; then
+    echo "Error: File not found: $usage_file"
+    exit 1
+  fi
+  _file_to=$(jq -r '.to // empty' "$usage_file")
+  _file_subject=$(jq -r '.subject // empty' "$usage_file")
+  FILE_BODY=$(jq -r '.body // empty' "$usage_file")
+  FILE_CC_LINES=$(jq -r 'if .cc then (.cc | if type == "array" then .[] else . end) else empty end' "$usage_file" 2>/dev/null || true)
+  [ -n "$_file_to" ] && TO="$_file_to"
+  [ -n "$_file_subject" ] && SUBJECT="$_file_subject"
+fi
 
 if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
-  echo "Usage: emails send <to> <subject> [body]"
+  echo "Usage: emails send --to <to> --subject <subject> [body options]"
   echo ""
-  echo "Body can be provided exactly one way:"
-  echo "  emails send admin@ricon.family 'Subject' 'inline body'"
-  echo "  emails send admin@ricon.family 'Subject' -b 'flag body'"
-  echo "  emails send admin@ricon.family 'Subject' -b /path/to/file.txt"
-  echo "  cat body.txt | emails send admin@ricon.family 'Subject'"
+  echo "Preferred (explicit flags — safe for agents):"
+  echo "  emails send --to admin@ricon.family --subject 'Update' -b body.txt"
+  echo "  emails send --to admin@ricon.family --subject 'Update' < body.txt"
+  echo "  emails send --file email.json"
   echo ""
-  echo "HTML email:"
-  echo "  emails send admin@ricon.family 'Subject' --html -b /path/to/file.html"
-  echo "  cat body.html | emails send admin@ricon.family 'Subject' --html"
+  echo "Positional form (compatible, prefer flags for new scripts):"
+  echo "  emails send admin@ricon.family 'Update' 'inline body'"
   echo ""
-  echo "Attachments:"
   echo "CC:"
-  echo "  emails send admin@ricon.family 'Subject' 'body' -c other@ricon.family"
-  echo "  emails send admin@ricon.family 'Subject' 'body' -c one@x.com -c two@x.com"
+  echo "  emails send --to admin@ricon.family --cc other@ricon.family --subject 'Update' -b body.txt"
   echo ""
-  echo "Attachments:"
-  echo "  emails send admin@ricon.family 'Subject' 'body' -a /path/to/file.pdf"
-  echo "  emails send admin@ricon.family 'Subject' 'body' -a one.pdf -a two.pdf"
+  echo "HTML:"
+  echo "  emails send --to admin@ricon.family --subject 'Update' --html -b file.html"
+  echo ""
+  echo "JSON file (to/subject/body/cc fields):"
+  echo "  emails send --file email.json"
   echo ""
   echo "Messages are GPG-signed automatically."
   exit 1
 fi
 
-# Body from positional arg or -b/--body flag. The positional arg is named
-# `body_arg` so it does not collide with the flag's `usage_body`; defaults on
-# both values clear inherited parent `usage_*` env.
+# GHL safety check: subject that looks like an email address means two recipients
+# were passed positionally (the original GHL referral incident).
+if echo "$SUBJECT" | grep -qE '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
+  echo "Error: subject looks like an email address: '$SUBJECT'"
+  echo "Did you accidentally pass two recipients positionally?"
+  echo "Use --cc for additional recipients:"
+  echo "  emails send --to $TO --cc $SUBJECT --subject 'Your subject here' ..."
+  exit 1
+fi
+
+# Body resolution: --file body > -b flag > positional arg.
+# --file body and -b/positional are mutually exclusive.
 BODY_ARG="${usage_body_arg:-}"
 BODY_FLAG="${usage_body:-}"
+if [ -n "$FILE_BODY" ] && { [ -n "$BODY_FLAG" ] || [ -n "$BODY_ARG" ]; }; then
+  echo "Error: --file already provides a body; do not also use -b or a positional body"
+  exit 1
+fi
 if [ -n "$BODY_ARG" ] && [ -n "$BODY_FLAG" ]; then
   echo "Error: Provide message body either positionally or with -b/--body, not both"
   exit 1
 fi
-BODY="${BODY_FLAG:-$BODY_ARG}"
+BODY="${FILE_BODY:-${BODY_FLAG:-$BODY_ARG}}"
 [ "$BODY" = "-" ] && BODY=""
 
 # If BODY looks like a file path and the file exists, read its contents
@@ -114,11 +145,18 @@ if [ "$ATTACH_COUNT" -gt 0 ]; then
   done
 fi
 
-# Build CC header
+# Build CC header: combine addresses from --file and --cc flags
 CC_HEADER=""
 CC_ADDRS=""
 CCS=()
 CC_COUNT=0
+
+if [ -n "$FILE_CC_LINES" ]; then
+  while IFS= read -r cc; do
+    [ -n "$cc" ] && CCS+=("$cc") && CC_COUNT=$((CC_COUNT + 1))
+  done <<< "$FILE_CC_LINES"
+fi
+
 while IFS= read -r cc; do
   if [ -n "$cc" ]; then
     CCS+=("$cc")

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -16,9 +16,39 @@ set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/email.sh"
 
-# Resolve TO and SUBJECT: explicit flags override positional args
-TO="${usage_to:-${usage_to_arg:-}}"
-SUBJECT="${usage_subject:-${usage_subject_arg:-}}"
+json_string_field() {
+  local file="$1"
+  local field="$2"
+  jq -r --arg field "$field" '
+    if has($field) and .[$field] != null then
+      if (.[$field] | type) == "string" then .[$field]
+      else error($field + " must be a string")
+      end
+    else empty end
+  ' "$file"
+}
+
+json_cc_lines() {
+  local file="$1"
+  jq -r '
+    if has("cc") and .cc != null then
+      if (.cc | type) == "array" then
+        if all(.cc[]; type == "string") then .cc[]
+        else error("cc array must contain only strings")
+        end
+      elif (.cc | type) == "string" then .cc
+      else error("cc must be a string or array of strings")
+      end
+    else empty end
+  ' "$file"
+}
+
+# Resolution order: positionals < --file < explicit flags. The GHL guard only
+# applies to subjects resolved from the ambiguous positional slot.
+TO="${usage_to_arg:-}"
+SUBJECT="${usage_subject_arg:-}"
+SUBJECT_SOURCE=""
+[ -n "$SUBJECT" ] && SUBJECT_SOURCE="positional"
 
 # --file: load TO/SUBJECT/BODY/CC from a JSON spec
 FILE_BODY=""
@@ -28,12 +58,35 @@ if [ -n "${usage_file:-}" ]; then
     echo "Error: File not found: $usage_file"
     exit 1
   fi
-  _file_to=$(jq -r '.to // empty' "$usage_file")
-  _file_subject=$(jq -r '.subject // empty' "$usage_file")
-  FILE_BODY=$(jq -r '.body // empty' "$usage_file")
-  FILE_CC_LINES=$(jq -r 'if .cc then (.cc | if type == "array" then .[] else . end) else empty end' "$usage_file" 2>/dev/null || true)
+  if ! _file_to=$(json_string_field "$usage_file" to); then
+    echo "Error: invalid --file to field"
+    exit 1
+  fi
+  if ! _file_subject=$(json_string_field "$usage_file" subject); then
+    echo "Error: invalid --file subject field"
+    exit 1
+  fi
+  if ! FILE_BODY=$(json_string_field "$usage_file" body); then
+    echo "Error: invalid --file body field"
+    exit 1
+  fi
+  if ! FILE_CC_LINES=$(json_cc_lines "$usage_file"); then
+    echo "Error: invalid --file cc field"
+    exit 1
+  fi
   [ -n "$_file_to" ] && TO="$_file_to"
-  [ -n "$_file_subject" ] && SUBJECT="$_file_subject"
+  if [ -n "$_file_subject" ]; then
+    SUBJECT="$_file_subject"
+    SUBJECT_SOURCE="file"
+  fi
+fi
+
+if [ -n "${usage_to:-}" ]; then
+  TO="$usage_to"
+fi
+if [ -n "${usage_subject:-}" ]; then
+  SUBJECT="$usage_subject"
+  SUBJECT_SOURCE="flag"
 fi
 
 if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
@@ -62,7 +115,7 @@ fi
 
 # GHL safety check: subject that looks like an email address means two recipients
 # were passed positionally (the original GHL referral incident).
-if echo "$SUBJECT" | grep -qE '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
+if [ "$SUBJECT_SOURCE" = "positional" ] && echo "$SUBJECT" | grep -qE '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
   echo "Error: subject looks like an email address: '$SUBJECT'"
   echo "Did you accidentally pass two recipients positionally?"
   echo "Use --cc for additional recipients:"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -61,8 +61,10 @@ setup_mock_himalaya() {
   # Track calls for assertions
   export MOCK_HIMALAYA_CALLS="$BATS_TEST_TMPDIR/himalaya-calls.log"
   export MOCK_HIMALAYA_ARGV_CALLS="$BATS_TEST_TMPDIR/himalaya-argv-calls.log"
+  export MOCK_HIMALAYA_STDIN="$BATS_TEST_TMPDIR/himalaya-stdin.log"
   : > "$MOCK_HIMALAYA_CALLS"
   : > "$MOCK_HIMALAYA_ARGV_CALLS"
+  : > "$MOCK_HIMALAYA_STDIN"
 
   cat > "$MOCK_BIN/himalaya" <<'MOCK'
 #!/usr/bin/env bash
@@ -76,6 +78,10 @@ echo "$@" >> "$MOCK_HIMALAYA_CALLS"
   done
   printf '\n'
 } >> "$MOCK_HIMALAYA_ARGV_CALLS"
+
+if [ "${1:-} ${2:-}" = "template send" ]; then
+  cat >> "$MOCK_HIMALAYA_STDIN"
+fi
 
 # Read canned response if set
 if [ -n "${MOCK_HIMALAYA_RESPONSE:-}" ] && [ -f "$MOCK_HIMALAYA_RESPONSE" ]; then
@@ -97,6 +103,10 @@ set_mock_response() {
 # Assert himalaya was called with specific args
 assert_himalaya_called() {
   grep -qF -- "$1" "$MOCK_HIMALAYA_CALLS"
+}
+
+himalaya_stdin() {
+  cat "$MOCK_HIMALAYA_STDIN"
 }
 
 # Count himalaya calls matching a pattern

--- a/test/integration/send.bats
+++ b/test/integration/send.bats
@@ -101,3 +101,44 @@ HTML
   [[ "$output" == *"alice@example.com"* ]]
   [[ "$output" == *"bob@example.com"* ]]
 }
+
+@test "send: --to and --subject flags deliver message" {
+  local body_file="$BATS_TEST_TMPDIR/body.txt"
+  echo "This message uses explicit --to and --subject flags instead of positional arguments for safety." > "$body_file"
+
+  emails send \
+    --to test-agent@ricon.family \
+    --subject "Explicit flags integration test" \
+    -b "$body_file"
+
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Explicit flags integration test"* ]]
+}
+
+@test "send: rejects two recipient-looking positional args (GHL shape)" {
+  run emails send alice@example.com candi@example.com \
+    "This body is long enough but should never be sent because the subject is an email."
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"subject looks like an email address"* ]]
+}
+
+@test "send: --file JSON delivers message with correct headers" {
+  local spec="$BATS_TEST_TMPDIR/email.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "test-agent@ricon.family",
+  "subject": "File spec integration test",
+  "body": "This message was composed from a JSON file spec to test the structured input path end to end.",
+  "cc": ["cc-recipient@example.com"]
+}
+JSON
+
+  emails send --file "$spec"
+
+  local sent_msg
+  sent_msg=$(find "$MAILDIR_ROOT/Sent" -type f | head -1)
+  run cat "$sent_msg"
+  [[ "$output" == *"File spec integration test"* ]]
+  [[ "$output" == *"cc-recipient@example.com"* ]]
+}

--- a/test/send.bats
+++ b/test/send.bats
@@ -150,6 +150,10 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
   assert_himalaya_called "template send"
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: user@example.com"* ]]
+  [[ "$mml" == *"Subject: Explicit flags test"* ]]
+  [[ "$mml" == *"$body"* ]]
 }
 
 @test "send: --to and --subject flags override positionals" {
@@ -157,6 +161,17 @@ setup() {
   run emails send positional@example.com "Positional subject" --to flag@example.com --subject "Flag subject" "$body"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to flag@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: flag@example.com"* ]]
+  [[ "$mml" == *"Subject: Flag subject"* ]]
+}
+
+@test "send: explicit --subject may look like an email address" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send --to user@example.com --subject candi@example.com -b "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  assert_himalaya_called "template send"
 }
 
 # ============================================================================
@@ -176,6 +191,10 @@ JSON
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
   assert_himalaya_called "template send"
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: user@example.com"* ]]
+  [[ "$mml" == *"Subject: File spec test"* ]]
+  [[ "$mml" == *"structured agent email sending"* ]]
 }
 
 @test "send: --file JSON with cc array" {
@@ -192,6 +211,74 @@ JSON
   [ "$status" -eq 0 ]
   [[ "$output" == *"cc:"* ]]
   [[ "$output" == *"alice@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"Cc: alice@example.com, bob@example.com"* ]]
+}
+
+@test "send: --file subject may look like an email address" {
+  local spec="$BATS_TEST_TMPDIR/email-subject.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "candi@example.com",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"Subject: candi@example.com"* ]]
+}
+
+@test "send: flags override --file to and subject" {
+  local spec="$BATS_TEST_TMPDIR/email-override.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "file@example.com",
+  "subject": "File subject",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending."
+}
+JSON
+  run emails send --file "$spec" --to flag@example.com --subject "Flag subject"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to flag@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: flag@example.com"* ]]
+  [[ "$mml" == *"Subject: Flag subject"* ]]
+  [[ "$mml" != *"To: file@example.com"* ]]
+  [[ "$mml" != *"Subject: File subject"* ]]
+}
+
+@test "send: --file rejects non-string body field" {
+  local spec="$BATS_TEST_TMPDIR/email-bad-body.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "Bad body field",
+  "body": ["not", "a", "string"]
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid --file body field"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "send: --file rejects non-string cc entries" {
+  local spec="$BATS_TEST_TMPDIR/email-bad-cc.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "Bad cc field",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending.",
+  "cc": ["alice@example.com", 42]
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid --file cc field"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
 }
 
 @test "send: --file missing file errors" {

--- a/test/send.bats
+++ b/test/send.bats
@@ -128,6 +128,93 @@ setup() {
 }
 
 # ============================================================================
+# GHL safety check
+# ============================================================================
+
+@test "send: rejects subject that looks like an email address" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send user@example.com candi@example.com "$body"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"subject looks like an email address"* ]]
+  [[ "$output" == *"--cc"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+# ============================================================================
+# Explicit --to / --subject flags
+# ============================================================================
+
+@test "send: --to and --subject flags work" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send --to user@example.com --subject "Explicit flags test" -b "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  assert_himalaya_called "template send"
+}
+
+@test "send: --to and --subject flags override positionals" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send positional@example.com "Positional subject" --to flag@example.com --subject "Flag subject" "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to flag@example.com"* ]]
+}
+
+# ============================================================================
+# --file structured input
+# ============================================================================
+
+@test "send: --file JSON input sends message" {
+  local spec="$BATS_TEST_TMPDIR/email.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "File spec test",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  assert_himalaya_called "template send"
+}
+
+@test "send: --file JSON with cc array" {
+  local spec="$BATS_TEST_TMPDIR/email-cc.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "CC file test",
+  "body": "This is the message body loaded from the JSON file spec for CC testing in structured input.",
+  "cc": ["alice@example.com", "bob@example.com"]
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cc:"* ]]
+  [[ "$output" == *"alice@example.com"* ]]
+}
+
+@test "send: --file missing file errors" {
+  run emails send --file /nonexistent/email.json
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"File not found"* ]]
+}
+
+@test "send: --file body and -b flag are mutually exclusive" {
+  local spec="$BATS_TEST_TMPDIR/email-body.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "Conflict test",
+  "body": "Body from file that is long enough to pass the minimum body length validation check."
+}
+JSON
+  run emails send --file "$spec" -b "extra body"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already provides a body"* ]]
+}
+
+# ============================================================================
 # Identity
 # ============================================================================
 


### PR DESCRIPTION
Closes #23

## Summary

- **`--to` / `--subject` flags** — explicit named flags are available alongside positionals; flags take priority over file and positional values, making agent-generated invocations unambiguous.
- **GHL safety check** — rejects the original ambiguous positional failure shape where the resolved positional subject looks like an email address, and hints to use `--cc` instead.
- **`--file <json>`** — structured JSON input (`to`, `subject`, `body`, `cc`) parsed via `jq`; leaves an auditable artifact before sending.
- **Structured input validation** — rejects non-string `to` / `subject` / `body` values and non-string `cc` entries before sending.
- **CC from `--file` + `--cc` combined** — file-specified CC and flag CC are merged.
- **Help text updated** to lead with the safe explicit-flag form.

## New invocation patterns

```bash
# Preferred (safe for agents)
emails send --to alice@example.com --subject "Update" -b body.txt
emails send --to alice@example.com --subject "Update" < body.txt

# Structured file
emails send --file email.json

# CC
emails send --to alice@example.com --cc candi@example.com --subject "Update" -b body.txt

# Positional (still works, backward-compatible)
emails send alice@example.com "Update" "inline body"
```

## Changes

| File | What changed |
|---|---|
| `.mise/tasks/send` | `--to`, `--subject`, `--file` flags; positional-only GHL check; validated structured input; merged CC; updated help |
| `test/helpers.bash` | mock `himalaya` captures send MML stdin for header/body assertions |
| `test/send.bats` | unit coverage for explicit flags, GHL shape, structured file input, invalid field types, and rendered MML |
| `test/integration/send.bats` | integration coverage for explicit flags delivery, GHL rejection, and `--file` end-to-end |

## Test plan

- [x] `bash -n .mise/tasks/send test/send.bats test/integration/send.bats test/helpers.bash test/integration-helpers.bash`
- [x] `mise run test` — 79/79 passing
- [x] `mise run test-integration` — 30/30 passing
- [x] configured codebase lints passed: `mise-settings`, `gum-table`, `or-true`
- [x] changed-file `codebase lint:shellcheck` passed for send/helper surfaces
- [x] `git diff --check origin/main...HEAD`
