### PR TITLE
fix: sign email with account key

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -11,6 +11,45 @@ MAIL_SERVER="mail.ricon.family"
 
 CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
 CONFIG_DIR="$(dirname "$CONFIG_FILE")"
+LEGACY_SIGN_CMD='pgp.sign-cmd = "gpg --sign --quiet --armor"'
+DESIRED_SIGN_CMD="pgp.sign-cmd = \"gpg --local-user $EMAIL --sign --quiet --armor\""
+
+migrate_legacy_sign_cmd() {
+  local tmp_config awk_status
+
+  tmp_config="${CONFIG_FILE}.tmp.$$"
+  awk_status=0
+
+  awk \
+    -v agent="$AGENT" \
+    -v legacy="$LEGACY_SIGN_CMD" \
+    -v desired="$DESIRED_SIGN_CMD" '
+      $0 ~ /^\[/ { in_account = ($0 == "[accounts." agent "]") }
+      in_account && $0 == legacy {
+        print desired
+        changed = 1
+        next
+      }
+      { print }
+      END { exit changed ? 0 : 42 }
+    ' "$CONFIG_FILE" > "$tmp_config" || awk_status=$?
+
+  case "$awk_status" in
+    0)
+      mv "$tmp_config" "$CONFIG_FILE"
+      return 0
+      ;;
+    42)
+      rm -f "$tmp_config"
+      return 1
+      ;;
+    *)
+      rm -f "$tmp_config"
+      echo "ERROR: failed to inspect GPG signing command in $CONFIG_FILE" >&2
+      return "$awk_status"
+      ;;
+  esac
+}
 
 # Check if himalaya is available
 if ! command -v himalaya &> /dev/null; then
@@ -22,26 +61,21 @@ fi
 # Check if already configured. Older setup wrote a bare `gpg --sign`, which
 # can pick another agent's default key on multi-agent machines; migrate that
 # account in place instead of requiring manual reconfiguration.
-if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
-  if awk -v agent="$AGENT" '
-    $0 == "[accounts." agent "]" { in_account = 1 }
-    in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
-    in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" { found = 1 }
-    END { exit found ? 0 : 1 }
-  ' "$CONFIG_FILE"; then
-    TMP_CONFIG="${CONFIG_FILE}.tmp.$$"
-    awk -v agent="$AGENT" -v email="$EMAIL" '
-      $0 == "[accounts." agent "]" { in_account = 1 }
-      in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
-      in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" {
-        print "pgp.sign-cmd = \"gpg --local-user " email " --sign --quiet --armor\""
-        next
-      }
-      { print }
-    ' "$CONFIG_FILE" > "$TMP_CONFIG"
-    mv "$TMP_CONFIG" "$CONFIG_FILE"
-    echo "Updated GPG signing command for $EMAIL"
-  fi
+if [ -f "$CONFIG_FILE" ] && grep -qF "[accounts.$AGENT]" "$CONFIG_FILE" 2>/dev/null; then
+  migrate_status=0
+  migrate_legacy_sign_cmd || migrate_status=$?
+
+  case "$migrate_status" in
+    0)
+      echo "Updated GPG signing command for $EMAIL"
+      ;;
+    1)
+      echo "GPG signing command already account-specific or custom for $EMAIL"
+      ;;
+    *)
+      exit "$migrate_status"
+      ;;
+  esac
 
   echo "Email already configured for $EMAIL"
   echo "Config: $CONFIG_FILE"

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -19,8 +19,30 @@ if ! command -v himalaya &> /dev/null; then
   exit 1
 fi
 
-# Check if already configured
+# Check if already configured. Older setup wrote a bare `gpg --sign`, which
+# can pick another agent's default key on multi-agent machines; migrate that
+# account in place instead of requiring manual reconfiguration.
 if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+  if awk -v agent="$AGENT" '
+    $0 == "[accounts." agent "]" { in_account = 1 }
+    in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
+    in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$CONFIG_FILE"; then
+    TMP_CONFIG="${CONFIG_FILE}.tmp.$$"
+    awk -v agent="$AGENT" -v email="$EMAIL" '
+      $0 == "[accounts." agent "]" { in_account = 1 }
+      in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
+      in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" {
+        print "pgp.sign-cmd = \"gpg --local-user " email " --sign --quiet --armor\""
+        next
+      }
+      { print }
+    ' "$CONFIG_FILE" > "$TMP_CONFIG"
+    mv "$TMP_CONFIG" "$CONFIG_FILE"
+    echo "Updated GPG signing command for $EMAIL"
+  fi
+
   echo "Email already configured for $EMAIL"
   echo "Config: $CONFIG_FILE"
   echo ""

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -4,13 +4,13 @@
 
 set -euo pipefail
 
+# shellcheck disable=SC2154 # mise provides usage_agent from #USAGE.
 AGENT="$usage_agent"
 EMAIL="${AGENT}@ricon.family"
-DOMAIN="ricon.family"
 MAIL_SERVER="mail.ricon.family"
 
-CONFIG_DIR="${HOME}/.config/himalaya"
-CONFIG_FILE="${CONFIG_DIR}/config.toml"
+CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
+CONFIG_DIR="$(dirname "$CONFIG_FILE")"
 
 # Check if himalaya is available
 if ! command -v himalaya &> /dev/null; then
@@ -80,7 +80,7 @@ downloads-dir = "$HOME/agents/$AGENT/downloads"
 
 # GPG signing (requires gpg:setup first)
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user $EMAIL --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 ACCOUNT_EOF

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
-#MISE description="Run all tests"
+#MISE description="Run BATS tests"
+#USAGE arg "[args]" var=#true help="Test suites or bats arguments"
+#USAGE example "mise run test" header="Run all unit tests"
+#USAGE example "mise run test setup" header="Run a specific suite by name"
+#USAGE example "mise run test --filter signing" header="Filter tests by name"
 
 set -euo pipefail
 
-bats --print-output-on-failure "$MISE_CONFIG_ROOT/test/"
+TEST_DIR="$MISE_CONFIG_ROOT/test"
+
+args=()
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    [ -z "$arg" ] && continue
+    args+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+fi
+
+resolved=()
+has_target=false
+
+for arg in ${args[@]+"${args[@]}"}; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    resolved+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    resolved+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  resolved+=("$TEST_DIR/")
+fi
+
+bats --print-output-on-failure "${resolved[@]}"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
-[![tests: 116 passing](https://img.shields.io/badge/tests-116%20passing-brightgreen?style=flat)](test/)
+[![tests: 118 passing](https://img.shields.io/badge/tests-118%20passing-brightgreen?style=flat)](test/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -113,9 +113,9 @@ A minimum body length of 50 characters guards against accidental sends. Override
 
 ## Testing
 
-116 tests across two suites:
+118 tests across two suites:
 
-- **Unit tests (81)** — mock himalaya, test task logic in isolation
+- **Unit tests (83)** — mock himalaya, test task logic in isolation
 - **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
-[![tests: 118 passing](https://img.shields.io/badge/tests-118%20passing-brightgreen?style=flat)](test/)
+[![tests: 122 passing](https://img.shields.io/badge/tests-122%20passing-brightgreen?style=flat)](test/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -113,9 +113,9 @@ A minimum body length of 50 characters guards against accidental sends. Override
 
 ## Testing
 
-118 tests across two suites:
+122 tests across two suites:
 
-- **Unit tests (83)** — mock himalaya, test task logic in isolation
+- **Unit tests (87)** — mock himalaya, test task logic in isolation
 - **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip
 
 ```bash

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -44,7 +44,7 @@ message.send.backend.login = "test-agent@ricon.family"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.raw = "fake-password"
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user test-agent@ricon.family --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 EOF

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -56,7 +56,7 @@ message.send.backend.type = "sendmail"
 message.send.backend.cmd = "$sendmail"
 
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user test-agent@ricon.family --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 EOF

--- a/test/lint.bats
+++ b/test/lint.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# Repository lint checks
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+codebase_lint() {
+  cd "$REPO_DIR" && mise exec -- codebase lint "$REPO_DIR"
+}
+export -f codebase_lint
+
+@test "lint: codebase checks pass" {
+  run codebase_lint
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"codebase: all 3 lint rule(s) passed"* ]]
+}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -34,3 +34,26 @@ EOF
   grep -qF 'pgp.sign-cmd = "gpg --local-user k7r2@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   grep -qF 'default = false' "$HIMALAYA_CONFIG"
 }
+
+@test "setup: migrates existing bare GPG signing command" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.zeke]
+default = true
+email = "zeke@ricon.family"
+pgp.sign-cmd = "gpg --local-user zeke@ricon.family --sign --quiet --armor"
+
+[accounts.c0da]
+default = false
+email = "c0da@ricon.family"
+pgp.sign-cmd = "gpg --sign --quiet --armor"
+EOF
+
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Updated GPG signing command for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  run ! grep -qF 'pgp.sign-cmd = "gpg --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  [ "$(grep -c '^\[accounts\.c0da\]$' "$HIMALAYA_CONFIG")" -eq 1 ]
+}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -57,3 +57,37 @@ EOF
   run ! grep -qF 'pgp.sign-cmd = "gpg --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   [ "$(grep -c '^\[accounts\.c0da\]$' "$HIMALAYA_CONFIG")" -eq 1 ]
 }
+
+@test "setup: leaves existing account-specific GPG signing command unchanged" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.c0da]
+default = true
+email = "c0da@ricon.family"
+pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"
+EOF
+
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GPG signing command already account-specific or custom for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  [ "$(grep -c 'pgp.sign-cmd =' "$HIMALAYA_CONFIG")" -eq 1 ]
+}
+
+@test "setup: leaves custom GPG signing command unchanged" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.c0da]
+default = true
+email = "c0da@ricon.family"
+pgp.sign-cmd = "custom-sign --identity c0da"
+EOF
+
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GPG signing command already account-specific or custom for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "custom-sign --identity c0da"' "$HIMALAYA_CONFIG"
+  run ! grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Tests for emails setup task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_mock_himalaya
+  export HIMALAYA_CONFIG="$BATS_TEST_TMPDIR/himalaya/config.toml"
+  export EMAIL_PASSWORD="fake-password"
+}
+
+@test "setup: configures account-specific GPG signing key" {
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Email configured for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+}
+
+@test "setup: appended account uses its own signing key" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.zeke]
+default = true
+email = "zeke@ricon.family"
+pgp.sign-cmd = "gpg --local-user zeke@ricon.family --sign --quiet --armor"
+EOF
+
+  run emails setup k7r2
+
+  [ "$status" -eq 0 ]
+  grep -qF '[accounts.k7r2]' "$HIMALAYA_CONFIG"
+  grep -qF 'pgp.sign-cmd = "gpg --local-user k7r2@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  grep -qF 'default = false' "$HIMALAYA_CONFIG"
+}


### PR DESCRIPTION
## Summary

Fix local multi-agent email signing by making `emails setup` generate account-specific GPG signing commands:

```toml
pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"
```

Without `--local-user`, bare `gpg --sign` can choose the first/default secret key on a multi-agent machine. Locally that was Zeke, so messages with `From: c0da@ricon.family` or `From: k7r2@ricon.family` could be signed by Zeke.

Also:

- `setup` now honors `HIMALAYA_CONFIG`, so tests can exercise setup without mutating real home config;
- test fixture configs use account-specific signing;
- setup tests cover first account and appended account cases;
- README test count refreshed to 118.

## Validation

- `bash -n .mise/tasks/setup test/setup.bats test/helpers.bash test/integration-helpers.bash`
- `mise exec shellcheck@0.11.0 -- shellcheck .mise/tasks/setup test/setup.bats test/helpers.bash test/integration-helpers.bash`
- `mise run test` — 83/83
- `mise run test-integration` — 35/35
- `/Users/rikonor/.local/share/mise/installs/shiv-readme/0.3.1/bin/readme build --check`
- `mise exec -- codebase lint:mise-settings "$PWD"`
- `mise exec -- codebase lint:gum-table "$PWD"`
- `mise exec -- codebase lint:or-true "$PWD"`
- `git diff --check`

Local machine config was also patched separately: `~/.config/himalaya/config.toml` now uses `--local-user <agent>@ricon.family` for existing accounts. Backup: `~/.config/himalaya/config.toml.bak-20260602181640`.
