### PR TITLE
fix: migrate existing email signing configs

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -19,8 +19,30 @@ if ! command -v himalaya &> /dev/null; then
   exit 1
 fi
 
-# Check if already configured
+# Check if already configured. Older setup wrote a bare `gpg --sign`, which
+# can pick another agent's default key on multi-agent machines; migrate that
+# account in place instead of requiring manual reconfiguration.
 if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+  if awk -v agent="$AGENT" '
+    $0 == "[accounts." agent "]" { in_account = 1 }
+    in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
+    in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$CONFIG_FILE"; then
+    TMP_CONFIG="${CONFIG_FILE}.tmp.$$"
+    awk -v agent="$AGENT" -v email="$EMAIL" '
+      $0 == "[accounts." agent "]" { in_account = 1 }
+      in_account && $0 ~ /^\[accounts\.[^]]+\]$/ && $0 != "[accounts." agent "]" { in_account = 0 }
+      in_account && $0 == "pgp.sign-cmd = \"gpg --sign --quiet --armor\"" {
+        print "pgp.sign-cmd = \"gpg --local-user " email " --sign --quiet --armor\""
+        next
+      }
+      { print }
+    ' "$CONFIG_FILE" > "$TMP_CONFIG"
+    mv "$TMP_CONFIG" "$CONFIG_FILE"
+    echo "Updated GPG signing command for $EMAIL"
+  fi
+
   echo "Email already configured for $EMAIL"
   echo "Config: $CONFIG_FILE"
   echo ""

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -34,3 +34,26 @@ EOF
   grep -qF 'pgp.sign-cmd = "gpg --local-user k7r2@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   grep -qF 'default = false' "$HIMALAYA_CONFIG"
 }
+
+@test "setup: migrates existing bare GPG signing command" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.zeke]
+default = true
+email = "zeke@ricon.family"
+pgp.sign-cmd = "gpg --local-user zeke@ricon.family --sign --quiet --armor"
+
+[accounts.c0da]
+default = false
+email = "c0da@ricon.family"
+pgp.sign-cmd = "gpg --sign --quiet --armor"
+EOF
+
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Updated GPG signing command for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  run ! grep -qF 'pgp.sign-cmd = "gpg --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  [ "$(grep -c '^\[accounts\.c0da\]$' "$HIMALAYA_CONFIG")" -eq 1 ]
+}


### PR DESCRIPTION
Fix-it for #29's existing-config gap.

`emails setup <agent>` currently exits early when the account already exists, so machines with configs generated before #29 keep the bare `gpg --sign --quiet --armor` command unless someone edits TOML by hand. This updates the existing account's legacy bare signing command in place and covers it with a setup test.

Validation:

- `bash -n .mise/tasks/setup test/setup.bats`
- `mise exec shellcheck@0.11.0 -- shellcheck .mise/tasks/setup test/setup.bats test/helpers.bash test/integration-helpers.bash`
- `mise run test` — 84/84
- `mise run test-integration` — 35/35
