### PR TITLE
Decouple email setup password source

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Setup email (himalaya) for an agent (one-time local setup)"
 #USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
+#USAGE flag "--password-stdin" default=#false help="Read email password from stdin instead of EMAIL_PASSWORD"
 
 set -euo pipefail
 
@@ -86,18 +87,26 @@ if [ -f "$CONFIG_FILE" ] && grep -qF "[accounts.$AGENT]" "$CONFIG_FILE" 2>/dev/n
   exit 0
 fi
 
-# Get password: env var > secrets tool > error
-if [ -z "${EMAIL_PASSWORD:-}" ]; then
-  # Empty result (missing key) is expected; we fall through to the empty-check below.
-  EMAIL_PASSWORD=$(secrets get "$AGENT/email-password" 2>/dev/null) || EMAIL_PASSWORD=""
+# Get password explicitly: stdin flag > env var > error.
+# Compose with any secret manager outside this tool by piping the password into setup.
+EMAIL_PASSWORD_VALUE=""
+if [ "${usage_password_stdin:-false}" = "true" ]; then
+  if [ -t 0 ]; then
+    echo "ERROR: --password-stdin was provided, but stdin is a terminal" >&2
+    echo "Pipe the password into setup, or use EMAIL_PASSWORD." >&2
+    exit 1
+  fi
+  EMAIL_PASSWORD_VALUE="$(cat)"
+elif [ -n "${EMAIL_PASSWORD:-}" ]; then
+  EMAIL_PASSWORD_VALUE="$EMAIL_PASSWORD"
 fi
 
-if [ -z "$EMAIL_PASSWORD" ]; then
-  echo "ERROR: Could not get email password for $AGENT"
-  echo ""
-  echo "Options:"
-  echo "  1. Store via: secrets set $AGENT/email-password"
-  echo "  2. Set EMAIL_PASSWORD env var manually"
+if [ -z "$EMAIL_PASSWORD_VALUE" ]; then
+  echo "ERROR: Could not get email password for $AGENT" >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  1. Set EMAIL_PASSWORD env var manually" >&2
+  echo "  2. Pipe a password: <command> | emails setup $AGENT --password-stdin" >&2
   exit 1
 fi
 
@@ -106,7 +115,7 @@ DOWNLOADS_DIR="${HOME}/agents/${AGENT}/downloads"
 mkdir -p "$DOWNLOADS_DIR"
 
 # Escape password for TOML basic string
-ESCAPED_PASSWORD=$(printf '%s' "$EMAIL_PASSWORD" | sed 's/\\/\\\\/g; s/"/\\"/g')
+ESCAPED_PASSWORD=$(printf '%s' "$EMAIL_PASSWORD_VALUE" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 # Build the account config block
 ACCOUNT_CONFIG=$(cat <<ACCOUNT_EOF

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
-[![tests: 122 passing](https://img.shields.io/badge/tests-122%20passing-brightgreen?style=flat)](test/)
+[![tests: 124 passing](https://img.shields.io/badge/tests-124%20passing-brightgreen?style=flat)](test/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -20,10 +20,14 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 shiv install emails
 ```
 
-First-time setup for an agent:
+First-time setup for an agent. Provide the password explicitly via environment or stdin; compose with your secret manager outside emails.
 
 ```bash
-emails setup <agent-name>
+# Environment variable
+EMAIL_PASSWORD="..." emails setup <agent-name>
+
+# Or stdin, usually from a password manager command
+password-manager get <agent-name>/email-password | emails setup <agent-name> --password-stdin
 ```
 
 ## Quick start
@@ -113,9 +117,9 @@ A minimum body length of 50 characters guards against accidental sends. Override
 
 ## Testing
 
-122 tests across two suites:
+124 tests across two suites:
 
-- **Unit tests (87)** — mock himalaya, test task logic in isolation
+- **Unit tests (89)** — mock himalaya, test task logic in isolation
 - **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip
 
 ```bash

--- a/README.tsx
+++ b/README.tsx
@@ -79,10 +79,14 @@ const readme = (
       <CodeBlock lang="bash">{`shiv install emails`}</CodeBlock>
 
       <Paragraph>
-        {"First-time setup for an agent:"}
+        {"First-time setup for an agent. Provide the password explicitly via environment or stdin; compose with your secret manager outside emails."}
       </Paragraph>
 
-      <CodeBlock lang="bash">{`emails setup <agent-name>`}</CodeBlock>
+      <CodeBlock lang="bash">{`# Environment variable
+EMAIL_PASSWORD="..." emails setup <agent-name>
+
+# Or stdin, usually from a password manager command
+password-manager get <agent-name>/email-password | emails setup <agent-name> --password-stdin`}</CodeBlock>
     </Section>
 
     <Section title="Quick start">

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,8 @@ bats = "1.13.0"
 bun = "1.3.12"
 "github:pimalaya/himalaya" = "1.2.0"
 gum = "0.17.0"
-"shiv:codebase" = "0.3.0"
+"shiv:codebase" = "0.3"
+"shiv:readme" = "0.3"
 
 [_.codebase]
 lint = ["mise-settings", "gum-table", "or-true"]

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -18,6 +18,28 @@ setup() {
   grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
 }
 
+@test "setup: reads password from stdin when requested" {
+  unset EMAIL_PASSWORD
+
+  run bash -c 'printf "%s" "stdin-password" | emails setup or --password-stdin'
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Email configured for or@ricon.family"* ]]
+  grep -qF 'backend.auth.raw = "stdin-password"' "$HIMALAYA_CONFIG"
+  grep -qF 'message.send.backend.auth.raw = "stdin-password"' "$HIMALAYA_CONFIG"
+}
+
+@test "setup: fails without an explicit password source" {
+  unset EMAIL_PASSWORD
+
+  run emails setup or
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not get email password for or"* ]]
+  [[ "$output" == *"Set EMAIL_PASSWORD env var manually"* ]]
+  [[ "$output" == *"emails setup or --password-stdin"* ]]
+}
+
 @test "setup: appended account uses its own signing key" {
   mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
   cat > "$HIMALAYA_CONFIG" <<'EOF'


### PR DESCRIPTION
## Summary

- remove the implicit `secrets get <agent>/email-password` fallback from `emails setup`
- add `emails setup <agent> --password-stdin` so callers can compose with any password manager explicitly
- keep `EMAIL_PASSWORD` env support
- add setup tests for stdin password and missing explicit password source
- declare `shiv:readme = "0.3"` and move `shiv:codebase` to minor-stream `0.3`

## Validation

- `mise install`
- `mise exec -- readme build --check`
- `mise run test setup`
- `mise run test`
- `mise run test-integration`
- `git pre-commit`
- `git pre-push` (warned only before upstream existed and because upstream merge commit signature status is not locally classified as good)
