### PR TITLE
fix: require exact GPG signer identity

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -13,7 +13,8 @@ MAIL_SERVER="mail.ricon.family"
 CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
 CONFIG_DIR="$(dirname "$CONFIG_FILE")"
 LEGACY_SIGN_CMD='pgp.sign-cmd = "gpg --sign --quiet --armor"'
-DESIRED_SIGN_CMD="pgp.sign-cmd = \"gpg --local-user $EMAIL --sign --quiet --armor\""
+OLD_ACCOUNT_SIGN_CMD="pgp.sign-cmd = \"gpg --local-user $EMAIL --sign --quiet --armor\""
+DESIRED_SIGN_CMD="pgp.sign-cmd = \"gpg --local-user '<$EMAIL>' --sign --quiet --armor\""
 
 migrate_legacy_sign_cmd() {
   local tmp_config awk_status
@@ -24,9 +25,10 @@ migrate_legacy_sign_cmd() {
   awk \
     -v agent="$AGENT" \
     -v legacy="$LEGACY_SIGN_CMD" \
+    -v old_account="$OLD_ACCOUNT_SIGN_CMD" \
     -v desired="$DESIRED_SIGN_CMD" '
       $0 ~ /^\[/ { in_account = ($0 == "[accounts." agent "]") }
-      in_account && $0 == legacy {
+      in_account && ($0 == legacy || $0 == old_account) {
         print desired
         changed = 1
         next
@@ -59,8 +61,9 @@ if ! command -v himalaya &> /dev/null; then
   exit 1
 fi
 
-# Check if already configured. Older setup wrote a bare `gpg --sign`, which
-# can pick another agent's default key on multi-agent machines; migrate that
+# Check if already configured. Older setup wrote either a bare `gpg --sign` or
+# an unbracketed `--local-user agent@ricon.family`. Both can pick another
+# agent's default/substring-matched key on multi-agent machines; migrate that
 # account in place instead of requiring manual reconfiguration.
 if [ -f "$CONFIG_FILE" ] && grep -qF "[accounts.$AGENT]" "$CONFIG_FILE" 2>/dev/null; then
   migrate_status=0
@@ -145,7 +148,7 @@ downloads-dir = "$HOME/agents/$AGENT/downloads"
 
 # GPG signing (requires gpg:setup first)
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --local-user $EMAIL --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user '<$EMAIL>' --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 ACCOUNT_EOF

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -6,13 +6,14 @@ set -euo pipefail
 
 AGENT="$usage_agent"
 EMAIL="${AGENT}@ricon.family"
-CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
+CONFIG_FILE="${HIMALAYA_CONFIG:-${HOME}/.config/himalaya/config.toml}"
+HIMALAYA_BIN="${HIMALAYA:-himalaya}"
 
 echo "Email status for $AGENT ($EMAIL)"
 echo ""
 
 # Check if himalaya is available
-if ! command -v himalaya &> /dev/null; then
+if ! command -v "$HIMALAYA_BIN" &> /dev/null; then
   echo "Himalaya installed: ✗"
   echo ""
   echo "Run: mise install"
@@ -30,7 +31,7 @@ fi
 echo "Config exists: ✓"
 
 # Check if agent account is configured
-if ! grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+if ! grep -qF "[accounts.$AGENT]" "$CONFIG_FILE" 2>/dev/null; then
   echo "Account configured: ✗"
   echo ""
   echo "Run: emails setup $AGENT"
@@ -41,7 +42,7 @@ echo "Account configured: ✓"
 # Try to connect (quick check)
 echo ""
 echo "Testing connection..."
-if himalaya envelope list --max-width 0 2>/dev/null | head -1 > /dev/null; then
+if "$HIMALAYA_BIN" envelope list -a "$AGENT" --max-width 0 2>/dev/null | head -1 > /dev/null; then
   echo "Connection: ✓"
 else
   echo "Connection: ✗ (check credentials)"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
-[![tests: 124 passing](https://img.shields.io/badge/tests-124%20passing-brightgreen?style=flat)](test/)
+[![tests: 127 passing](https://img.shields.io/badge/tests-127%20passing-brightgreen?style=flat)](test/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -87,7 +87,7 @@ emails reply 42 --html -b '<h1>Thanks!</h1><p>Got it.</p>'
 
 ## GPG signing
 
-All outgoing messages are GPG-signed automatically using the agent's key. This provides a unified cryptographic identity — the same key signs git commits and emails.
+All outgoing messages are GPG-signed automatically using the exact account email key. This provides a unified cryptographic identity — the same key signs git commits and emails, and a missing exact key fails instead of falling back to another agent's key.
 
 Incoming messages show signature status when read:
 
@@ -117,9 +117,9 @@ A minimum body length of 50 characters guards against accidental sends. Override
 
 ## Testing
 
-124 tests across two suites:
+127 tests across two suites:
 
-- **Unit tests (89)** — mock himalaya, test task logic in isolation
+- **Unit tests (92)** — mock himalaya, test task logic in isolation
 - **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip
 
 ```bash

--- a/README.tsx
+++ b/README.tsx
@@ -140,8 +140,8 @@ emails reply 42 --html -b '<h1>Thanks!</h1><p>Got it.</p>'`}</CodeBlock>
 
     <Section title="GPG signing">
       <Paragraph>
-        {"All outgoing messages are GPG-signed automatically using the agent's key. "}
-        {"This provides a unified cryptographic identity — the same key signs git commits and emails."}
+        {"All outgoing messages are GPG-signed automatically using the exact account email key. "}
+        {"This provides a unified cryptographic identity — the same key signs git commits and emails, and a missing exact key fails instead of falling back to another agent's key."}
       </Paragraph>
 
       <Paragraph>

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -44,7 +44,7 @@ message.send.backend.login = "test-agent@ricon.family"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.raw = "fake-password"
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --local-user test-agent@ricon.family --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user '<test-agent@ricon.family>' --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 EOF

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -56,7 +56,7 @@ message.send.backend.type = "sendmail"
 message.send.backend.cmd = "$sendmail"
 
 pgp.type = "commands"
-pgp.sign-cmd = "gpg --local-user test-agent@ricon.family --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user '<test-agent@ricon.family>' --sign --quiet --armor"
 pgp.decrypt-cmd = "gpg --decrypt --quiet"
 pgp.verify-cmd = "gpg --verify --quiet"
 EOF

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,12 +10,12 @@ setup() {
   export EMAIL_PASSWORD="fake-password"
 }
 
-@test "setup: configures account-specific GPG signing key" {
+@test "setup: configures account-specific GPG signing key exactly" {
   run emails setup c0da
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"Email configured for c0da@ricon.family"* ]]
-  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<c0da@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
 }
 
 @test "setup: reads password from stdin when requested" {
@@ -40,20 +40,20 @@ setup() {
   [[ "$output" == *"emails setup or --password-stdin"* ]]
 }
 
-@test "setup: appended account uses its own signing key" {
+@test "setup: appended account uses its own exact signing key" {
   mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
   cat > "$HIMALAYA_CONFIG" <<'EOF'
 [accounts.zeke]
 default = true
 email = "zeke@ricon.family"
-pgp.sign-cmd = "gpg --local-user zeke@ricon.family --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user '<zeke@ricon.family>' --sign --quiet --armor"
 EOF
 
   run emails setup k7r2
 
   [ "$status" -eq 0 ]
   grep -qF '[accounts.k7r2]' "$HIMALAYA_CONFIG"
-  grep -qF 'pgp.sign-cmd = "gpg --local-user k7r2@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<k7r2@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   grep -qF 'default = false' "$HIMALAYA_CONFIG"
 }
 
@@ -63,7 +63,7 @@ EOF
 [accounts.zeke]
 default = true
 email = "zeke@ricon.family"
-pgp.sign-cmd = "gpg --local-user zeke@ricon.family --sign --quiet --armor"
+pgp.sign-cmd = "gpg --local-user '<zeke@ricon.family>' --sign --quiet --armor"
 
 [accounts.c0da]
 default = false
@@ -75,12 +75,12 @@ EOF
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"Updated GPG signing command for c0da@ricon.family"* ]]
-  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<c0da@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   run ! grep -qF 'pgp.sign-cmd = "gpg --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   [ "$(grep -c '^\[accounts\.c0da\]$' "$HIMALAYA_CONFIG")" -eq 1 ]
 }
 
-@test "setup: leaves existing account-specific GPG signing command unchanged" {
+@test "setup: migrates existing unbracketed account-specific GPG signing command" {
   mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
   cat > "$HIMALAYA_CONFIG" <<'EOF'
 [accounts.c0da]
@@ -92,8 +92,26 @@ EOF
   run emails setup c0da
 
   [ "$status" -eq 0 ]
+  [[ "$output" == *"Updated GPG signing command for c0da@ricon.family"* ]]
+  grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<c0da@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  run ! grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  [ "$(grep -c 'pgp.sign-cmd =' "$HIMALAYA_CONFIG")" -eq 1 ]
+}
+
+@test "setup: leaves existing exact account-specific GPG signing command unchanged" {
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.c0da]
+default = true
+email = "c0da@ricon.family"
+pgp.sign-cmd = "gpg --local-user '<c0da@ricon.family>' --sign --quiet --armor"
+EOF
+
+  run emails setup c0da
+
+  [ "$status" -eq 0 ]
   [[ "$output" == *"GPG signing command already account-specific or custom for c0da@ricon.family"* ]]
-  grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<c0da@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
   [ "$(grep -c 'pgp.sign-cmd =' "$HIMALAYA_CONFIG")" -eq 1 ]
 }
 
@@ -111,5 +129,5 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"GPG signing command already account-specific or custom for c0da@ricon.family"* ]]
   grep -qF 'pgp.sign-cmd = "custom-sign --identity c0da"' "$HIMALAYA_CONFIG"
-  run ! grep -qF 'pgp.sign-cmd = "gpg --local-user c0da@ricon.family --sign --quiet --armor"' "$HIMALAYA_CONFIG"
+  run ! grep -qF 'pgp.sign-cmd = "gpg --local-user '\''<c0da@ricon.family>'\'' --sign --quiet --armor"' "$HIMALAYA_CONFIG"
 }

--- a/test/status.bats
+++ b/test/status.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Tests for emails status task
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+setup() {
+  setup_mock_himalaya
+  export HIMALAYA_CONFIG="$BATS_TEST_TMPDIR/himalaya/config.toml"
+  mkdir -p "$(dirname "$HIMALAYA_CONFIG")"
+  cat > "$HIMALAYA_CONFIG" <<'EOF'
+[accounts.or]
+default = false
+email = "or@ricon.family"
+
+[accounts.junior]
+default = true
+email = "junior@ricon.family"
+EOF
+}
+
+@test "status: checks the requested himalaya account" {
+  run emails status or
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Email status for or (or@ricon.family)"* ]]
+  [[ "$output" == *"Connection: ✓"* ]]
+  grep -qF -- 'envelope list -a or --max-width 0' "$MOCK_HIMALAYA_CALLS"
+}
+
+@test "status: honors HIMALAYA_CONFIG when checking account config" {
+  run emails status junior
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Account configured: ✓"* ]]
+}


### PR DESCRIPTION
## Summary

- generate setup GPG signing commands with the exact email selector (`--local-user '<agent@ricon.family>'`)
- migrate existing per-account bare `gpg --sign` and unbracketed account-specific `--local-user agent@ricon.family` commands to the exact selector
- fix `emails status <agent>` to honor `HIMALAYA_CONFIG`/`HIMALAYA` and check the requested himalaya account with `-a "$AGENT"`

## Validation

- `mise trust && mise install`
- `mise run test test/setup.bats test/status.bats`
- `mise run test` (92/92)
- `mise run test-integration` (35/35)
- `bun test src/` (44/44)
- `mise exec -- readme build --check`
- `git diff --check`

Degraded local hook checks: `git pre-commit` and `git pre-push` are not installed as git extension commands in this runner; `.git/hooks` only has sample hooks.

Or plans to review too.

Fixes #32
