### PR TITLE
fix(send): name the PGP/MIME signature attachment signature.asc (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+CLAUDE.md
+/memory/

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -102,7 +102,12 @@ if [ "$HAS_ATTACHMENT" = "true" ]; then
     while IFS= read -r fname; do
       [ -n "$fname" ] || continue
       f="$DOWNLOADS_DIR/$fname"
-      if [[ "$fname" != *.* ]] && file -b "$f" | grep -qi "pgp\|gpg"; then
+      # Drop detached PGP signatures from the listing. They arrive either with no
+      # extension (older himalaya) or named signature.asc/.pgp/.sig (our send task
+      # names them so Gmail shows a recognizable attachment); the file-type guard
+      # keeps us from discarding genuine user attachments with those extensions.
+      if { [[ "$fname" != *.* ]] || [[ "$fname" == *.asc ]] || [[ "$fname" == *.pgp ]] || [[ "$fname" == *.sig ]]; } \
+        && file -b "$f" | grep -qi "pgp\|gpg"; then
         rm -f "$f"
       else
         FOUND=$((FOUND + 1))

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -222,8 +222,9 @@ if [ "$CC_COUNT" -gt 0 ]; then
   CC_HEADER="Cc: $CC_ADDRS"
 fi
 
-# Send with GPG signing using MML template.
-"$HIMALAYA_BIN" template send -a "$AGENT" << EOF
+# Compose the message in MML. himalaya compiles this into an RFC 3156
+# multipart/signed message, GPG-signing the body (+ attachments) as a unit.
+MML=$(cat << EOF
 From: $FROM
 To: $TO
 ${CC_HEADER:+$CC_HEADER
@@ -236,6 +237,61 @@ $BODY
 $ATTACH_MML
 <#/multipart>
 EOF
+)
+
+# Newline-separated Drafts envelope ids (empty if folder empty/unavailable).
+drafts_ids() {
+  "$HIMALAYA_BIN" -o json envelope list -a "$AGENT" -f Drafts --page-size 1000 2>/dev/null \
+    | jq -r '.[].id' 2>/dev/null
+}
+
+# Permanently remove the transient draft copies (arg: space-separated ids) so they
+# do not pile up in Trash. `folder expunge` only drops the ids we flag deleted, so
+# any genuine drafts are left untouched.
+purge_drafts() {
+  [ -n "$1" ] || return 0
+  "$HIMALAYA_BIN" flag add -a "$AGENT" -f Drafts $1 deleted >/dev/null 2>&1
+  "$HIMALAYA_BIN" folder expunge -a "$AGENT" Drafts >/dev/null 2>&1
+}
+
+# Send the message with the detached PGP signature named "signature.asc" so
+# recipients (e.g. Gmail) see a recognizable attachment instead of "noname".
+# himalaya can't name the signature part itself (it is hardcoded unnamed in
+# pimalaya/core's mml compiler), and `template send` compiles+sends atomically, so
+# we intercept the compiled message: save it to Drafts (the only no-send compile
+# path), export the raw MIME, inject the signature filename headers, then send the
+# raw via `message send`. The draft copies are always purged on return.
+#
+# Returns non-zero (without sending) on any failure so the caller can fall back to
+# a plain signed send rather than dropping the message.
+send_named_signature() {
+  local tmp saved="" new_ids="" drafts_before drafts_after draft_id
+  tmp=$(mktemp -d) || return 1
+  # shellcheck disable=SC2064
+  trap 'rm -rf "$tmp"; [ -n "$saved" ] && purge_drafts "$new_ids"; trap - RETURN' RETURN
+
+  drafts_before=$(drafts_ids) || return 1
+  # NB: no `-o json` here — under json output himalaya's `template save` reads the
+  # template from its (empty) positional arg instead of stdin and fails to parse.
+  printf '%s' "$MML" | "$HIMALAYA_BIN" template save -a "$AGENT" -f Drafts >/dev/null 2>&1 || return 1
+  saved=1
+  drafts_after=$(drafts_ids) || return 1
+
+  # himalaya v1.2.0's `template save` writes the draft twice; diff before/after so
+  # cleanup removes every copy regardless of count.
+  new_ids=$(comm -13 <(printf '%s\n' "$drafts_before" | sort) <(printf '%s\n' "$drafts_after" | sort) | tr '\n' ' ')
+  draft_id=$(printf '%s\n' $new_ids | grep -m1 .)
+  [ -n "$draft_id" ] || return 1
+
+  "$HIMALAYA_BIN" message export --full -a "$AGENT" -f Drafts -d "$tmp/signed.eml" "$draft_id" >/dev/null 2>&1 || return 1
+  inject_signature_name < "$tmp/signed.eml" > "$tmp/named.eml" || return 1
+  "$HIMALAYA_BIN" message send -a "$AGENT" < "$tmp/named.eml" >/dev/null 2>&1 || return 1
+}
+
+if ! send_named_signature; then
+  echo "Note: named-signature send unavailable; falling back to standard signed send." >&2
+  printf '%s' "$MML" | "$HIMALAYA_BIN" template send -a "$AGENT"
+fi
 
 if [ -n "${CC_HEADER:-}" ]; then
   echo "Sent to $TO (cc: $CC_ADDRS)"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wraps [himalaya](https://github.com/pimalaya/himalaya) with agent identity, GPG 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
-[![tests: 124 passing](https://img.shields.io/badge/tests-124%20passing-brightgreen?style=flat)](test/)
+[![tests: 133 passing](https://img.shields.io/badge/tests-133%20passing-brightgreen?style=flat)](test/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -117,10 +117,10 @@ A minimum body length of 50 characters guards against accidental sends. Override
 
 ## Testing
 
-124 tests across two suites:
+133 tests across two suites:
 
-- **Unit tests (89)** — mock himalaya, test task logic in isolation
-- **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip
+- **Unit tests (97)** — mock himalaya, test task logic in isolation
+- **Integration tests (36)** — real himalaya against a local maildir backend, full round-trip
 
 ```bash
 mise run test              # unit tests

--- a/lib/email.sh
+++ b/lib/email.sh
@@ -31,3 +31,26 @@ if [ "${NEED_IMAP:-0}" = "1" ]; then
     return 1 2>/dev/null || exit 1
   fi
 fi
+
+# Name the detached PGP/MIME signature part so recipients (e.g. Gmail) see
+# "signature.asc" instead of "noname". himalaya/mml emit the signature part as a
+# bare `Content-Type: application/pgp-signature` with no name/disposition/description
+# (pimalaya/core mml/src/message/body/compiler/mod.rs), so we inject the standard
+# headers here. This is safe: a PGP/MIME signature covers only the canonicalised
+# clear part, never the signature part's own MIME headers, so the signature stays
+# valid. Reads a raw .eml on stdin, writes the rewritten message to stdout;
+# CRLF line endings are preserved.
+inject_signature_name() {
+  awk '
+    !done && tolower($0) ~ /^content-type:[[:space:]]*application\/pgp-signature[[:space:]]*\r?$/ {
+      cr = ""
+      if (sub(/\r$/, "")) cr = "\r"
+      print $0 "; name=\"signature.asc\"" cr
+      print "Content-Disposition: attachment; filename=\"signature.asc\"" cr
+      print "Content-Description: OpenPGP digital signature" cr
+      done = 1
+      next
+    }
+    { print }
+  '
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -62,12 +62,27 @@ setup_mock_himalaya() {
   export MOCK_HIMALAYA_CALLS="$BATS_TEST_TMPDIR/himalaya-calls.log"
   export MOCK_HIMALAYA_ARGV_CALLS="$BATS_TEST_TMPDIR/himalaya-argv-calls.log"
   export MOCK_HIMALAYA_STDIN="$BATS_TEST_TMPDIR/himalaya-stdin.log"
+  # Raw message captured by `message send` (the named-signature send path).
+  export MOCK_HIMALAYA_SEND_RAW="$BATS_TEST_TMPDIR/himalaya-send-raw.log"
+  # Simulated Drafts folder state (one envelope id per line).
+  export MOCK_DRAFTS_STATE="$BATS_TEST_TMPDIR/himalaya-drafts.state"
+  # Draft ids flagged \Deleted, awaiting `folder expunge`.
+  export MOCK_DRAFTS_DELETED="$BATS_TEST_TMPDIR/himalaya-drafts.deleted"
+  # Canned signed .eml that `message export --full` returns (a multipart/signed
+  # message with an unnamed application/pgp-signature part, like real himalaya).
+  export MOCK_SIGNED_EML="$BATS_TEST_TMPDIR/himalaya-signed.eml"
   : > "$MOCK_HIMALAYA_CALLS"
   : > "$MOCK_HIMALAYA_ARGV_CALLS"
   : > "$MOCK_HIMALAYA_STDIN"
+  : > "$MOCK_HIMALAYA_SEND_RAW"
+  : > "$MOCK_DRAFTS_STATE"
+  : > "$MOCK_DRAFTS_DELETED"
+  printf 'From: test-agent@ricon.family\r\nTo: user@example.com\r\nSubject: Mock signed\r\nMIME-Version: 1.0\r\nContent-Type: multipart/signed; boundary="bnd"; protocol="application/pgp-signature"; micalg="pgp-sha256"\r\n\r\n--bnd\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nmock signed body content\r\n--bnd\r\nContent-Type: application/pgp-signature\r\nContent-Transfer-Encoding: 7bit\r\n\r\n-----BEGIN PGP SIGNATURE-----\r\n\r\nmQ==mocksignaturebytes\r\n-----END PGP SIGNATURE-----\r\n--bnd--\r\n' > "$MOCK_SIGNED_EML"
 
   cat > "$MOCK_BIN/himalaya" <<'MOCK'
 #!/usr/bin/env bash
+HIMALAYA_ARGV=("$@")
+
 # Log the call (space-joined for existing substring assertions, and
 # length-prefixed argv for tests that need argument-boundary checks).
 echo "$@" >> "$MOCK_HIMALAYA_CALLS"
@@ -79,14 +94,86 @@ echo "$@" >> "$MOCK_HIMALAYA_CALLS"
   printf '\n'
 } >> "$MOCK_HIMALAYA_ARGV_CALLS"
 
-if [ "${1:-} ${2:-}" = "template send" ]; then
-  cat >> "$MOCK_HIMALAYA_STDIN"
-fi
+# Value following a flag in argv (e.g. flag_value -d -> the export destination).
+flag_value() {
+  local want="$1" i
+  for ((i = 0; i < ${#HIMALAYA_ARGV[@]}; i++)); do
+    if [ "${HIMALAYA_ARGV[i]}" = "$want" ]; then
+      echo "${HIMALAYA_ARGV[i + 1]:-}"
+      return 0
+    fi
+  done
+  return 1
+}
 
-# Read canned response if set
-if [ -n "${MOCK_HIMALAYA_RESPONSE:-}" ] && [ -f "$MOCK_HIMALAYA_RESPONSE" ]; then
-  cat "$MOCK_HIMALAYA_RESPONSE"
+# Subcommand pair, skipping a leading global `-o <fmt>` / `--output <fmt>`.
+args=("$@")
+if [ "${args[0]:-}" = "-o" ] || [ "${args[0]:-}" = "--output" ]; then
+  args=("${args[@]:2}")
 fi
+sub="${args[0]:-} ${args[1]:-}"
+
+case "$sub" in
+  "template send" | "template save")
+    # Capture the MML body for content assertions.
+    cat >> "$MOCK_HIMALAYA_STDIN"
+    # himalaya v1.2.0 `template save` writes the draft twice; mirror that so the
+    # send task's before/after diff + multi-id cleanup is exercised.
+    if [ "$sub" = "template save" ]; then
+      printf 'draft-%s\ndraft-%s\n' "$RANDOM$RANDOM" "$RANDOM$RANDOM" >> "$MOCK_DRAFTS_STATE"
+    fi
+    ;;
+  "envelope list")
+    if printf ' %s ' "${HIMALAYA_ARGV[@]}" | grep -q -- ' Drafts '; then
+      printf '['
+      first=1
+      while IFS= read -r id; do
+        [ -n "$id" ] || continue
+        [ "$first" = 1 ] || printf ','
+        printf '{"id":"%s"}' "$id"
+        first=0
+      done < "$MOCK_DRAFTS_STATE"
+      printf ']\n'
+    elif [ -n "${MOCK_HIMALAYA_RESPONSE:-}" ] && [ -f "$MOCK_HIMALAYA_RESPONSE" ]; then
+      cat "$MOCK_HIMALAYA_RESPONSE"
+    fi
+    ;;
+  "message export")
+    dest=$(flag_value -d || flag_value --destination)
+    if [ -n "$dest" ]; then
+      cp "$MOCK_SIGNED_EML" "$dest"
+    else
+      cat "$MOCK_SIGNED_EML"
+    fi
+    ;;
+  "message send")
+    cat >> "$MOCK_HIMALAYA_SEND_RAW"
+    ;;
+  "flag add")
+    # Record draft ids flagged for deletion (mock ids look like draft-NNNN).
+    for a in "${HIMALAYA_ARGV[@]}"; do
+      case "$a" in draft-*) echo "$a" >> "$MOCK_DRAFTS_DELETED" ;; esac
+    done
+    ;;
+  "folder expunge")
+    # Permanently drop the flagged ids from the simulated Drafts folder.
+    if printf ' %s ' "${HIMALAYA_ARGV[@]}" | grep -q -- ' Drafts ' && [ -s "$MOCK_DRAFTS_DELETED" ]; then
+      tmp=$(mktemp)
+      # grep exits 1 when no draft ids remain; the (possibly empty) output is what
+      # we want either way, and this mock does not run under `set -e`.
+      if ! grep -vxF -f "$MOCK_DRAFTS_DELETED" "$MOCK_DRAFTS_STATE" > "$tmp" 2>/dev/null; then
+        : # all drafts removed -> $tmp is empty
+      fi
+      mv "$tmp" "$MOCK_DRAFTS_STATE"
+      : > "$MOCK_DRAFTS_DELETED"
+    fi
+    ;;
+  *)
+    if [ -n "${MOCK_HIMALAYA_RESPONSE:-}" ] && [ -f "$MOCK_HIMALAYA_RESPONSE" ]; then
+      cat "$MOCK_HIMALAYA_RESPONSE"
+    fi
+    ;;
+esac
 MOCK
   chmod +x "$MOCK_BIN/himalaya"
 
@@ -107,6 +194,16 @@ assert_himalaya_called() {
 
 himalaya_stdin() {
   cat "$MOCK_HIMALAYA_STDIN"
+}
+
+# Raw message handed to `message send` (the named-signature send path).
+himalaya_send_raw() {
+  cat "$MOCK_HIMALAYA_SEND_RAW"
+}
+
+# Remaining simulated Drafts ids (empty when cleanup succeeded).
+drafts_state() {
+  cat "$MOCK_DRAFTS_STATE" 2>/dev/null
 }
 
 # Count himalaya calls matching a pattern

--- a/test/integration-helpers.bash
+++ b/test/integration-helpers.bash
@@ -140,6 +140,20 @@ MOCK
   export PATH="$mock_bin:$PATH"
 }
 
+# Generate an ephemeral GPG key for the test agent so `emails send` produces a
+# genuinely signed (multipart/signed) message. Without a key himalaya silently
+# degrades to an unsigned multipart/mixed, so only tests that assert on the real
+# signature need this. Scopes GNUPGHOME to the test tmpdir; bats isolates each
+# test, so it does not leak to other tests.
+setup_signing_key() {
+  export GNUPGHOME="$BATS_TEST_TMPDIR/gnupg"
+  mkdir -p "$GNUPGHOME"
+  chmod 700 "$GNUPGHOME"
+  gpg --batch --pinentry-mode loopback --passphrase '' \
+    --quick-generate-key "Test Agent <test-agent@ricon.family>" default default never \
+    >/dev/null 2>&1
+}
+
 # Get the envelope ID of the most recent message via himalaya
 latest_envelope_id() {
   local folder="${1:-INBOX}"

--- a/test/integration/send.bats
+++ b/test/integration/send.bats
@@ -37,6 +37,39 @@ setup() {
   [[ "$output" == *"@"* ]]
 }
 
+@test "send: names the PGP signature attachment and keeps it valid (issue #28)" {
+  setup_signing_key
+
+  emails send test-agent@ricon.family "Named signature test" \
+    "This message verifies the detached PGP signature is named signature.asc and still verifies."
+
+  local sent_msg
+  sent_msg=$(find "$MAILDIR_ROOT/Sent" -type f | head -1)
+  [ -n "$sent_msg" ]
+
+  # The message is really signed and the signature part is now recipient-friendly.
+  run cat "$sent_msg"
+  [[ "$output" == *"multipart/signed"* ]]
+  [[ "$output" == *'Content-Type: application/pgp-signature; name="signature.asc"'* ]]
+  [[ "$output" == *'Content-Disposition: attachment; filename="signature.asc"'* ]]
+  [[ "$output" == *'Content-Description: OpenPGP digital signature'* ]]
+
+  # Rewriting the signature part's own headers must not invalidate the signature
+  # (it covers only the signed clear part, never the signature part's MIME headers).
+  run gpg --verify "$sent_msg"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Good signature"* ]]
+
+  # The transient draft copies used to build the message must be cleaned up, and
+  # permanently — not left piling up in Trash.
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Drafts --page-size 100 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Named signature test"* ]]
+
+  run himalaya -c "$HIMALAYA_CONFIG" envelope list -a "$AGENT" -f Trash --page-size 100 2>/dev/null
+  [[ "$output" != *"Named signature test"* ]]
+}
+
 @test "send: rejects empty body" {
   run emails send test-agent@ricon.family "Empty body test" </dev/null
   [ "$status" -ne 0 ]

--- a/test/lib.bats
+++ b/test/lib.bats
@@ -90,3 +90,71 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "PASS=empty" ]
 }
+
+# ============================================================================
+# inject_signature_name — name the detached PGP/MIME signature part
+# ============================================================================
+
+# Provide a valid identity + config so sourcing lib/email.sh succeeds.
+_lib_identity() {
+  export GIT_AUTHOR_EMAIL="myagent@ricon.family"
+  cat > "$HIMALAYA_CONFIG" <<EOF
+[accounts.myagent]
+default = true
+EOF
+}
+
+# A himalaya-style multipart/signed message (CRLF) with an unnamed signature part.
+_signed_fixture() {
+  printf 'Content-Type: multipart/signed; boundary="b"; protocol="application/pgp-signature"; micalg="pgp-sha256"\r\n\r\n--b\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nclear body text\r\n--b\r\nContent-Type: application/pgp-signature\r\nContent-Transfer-Encoding: 7bit\r\n\r\n-----BEGIN PGP SIGNATURE-----\r\n\r\nMOCKSIG==\r\n-----END PGP SIGNATURE-----\r\n--b--\r\n' > "$1"
+}
+
+@test "inject_signature_name: adds name, disposition and description headers" {
+  _lib_identity
+  local fixture="$BATS_TEST_TMPDIR/sig.eml"
+  _signed_fixture "$fixture"
+
+  run bash -c "source '$REPO_DIR/lib/email.sh' && inject_signature_name < '$fixture'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'Content-Type: application/pgp-signature; name="signature.asc"'* ]]
+  [[ "$output" == *'Content-Disposition: attachment; filename="signature.asc"'* ]]
+  [[ "$output" == *'Content-Description: OpenPGP digital signature'* ]]
+}
+
+@test "inject_signature_name: leaves clear part and signature body unchanged" {
+  _lib_identity
+  local fixture="$BATS_TEST_TMPDIR/sig.eml"
+  _signed_fixture "$fixture"
+
+  run bash -c "source '$REPO_DIR/lib/email.sh' && inject_signature_name < '$fixture'"
+  [[ "$output" == *"clear body text"* ]]
+  [[ "$output" == *"-----BEGIN PGP SIGNATURE-----"* ]]
+  [[ "$output" == *"MOCKSIG=="* ]]
+  # The clear part's own Content-Type must not be touched.
+  [[ "$output" == *"Content-Type: text/plain; charset=utf-8"* ]]
+  [[ "$output" != *'text/plain; charset=utf-8; name="signature.asc"'* ]]
+}
+
+@test "inject_signature_name: rewrites the signature part exactly once" {
+  _lib_identity
+  local fixture="$BATS_TEST_TMPDIR/sig.eml"
+  _signed_fixture "$fixture"
+
+  local count
+  count=$(bash -c "source '$REPO_DIR/lib/email.sh' && inject_signature_name < '$fixture'" \
+    | grep -c 'pgp-signature; name="signature.asc"')
+  [ "$count" -eq 1 ]
+}
+
+@test "inject_signature_name: preserves CRLF and adds two CRLF-terminated headers" {
+  _lib_identity
+  local fixture="$BATS_TEST_TMPDIR/sig.eml"
+  _signed_fixture "$fixture"
+
+  local in_cr out_cr
+  in_cr=$(tr -cd '\r' < "$fixture" | wc -c)
+  out_cr=$(bash -c "source '$REPO_DIR/lib/email.sh' && inject_signature_name < '$fixture'" \
+    | tr -cd '\r' | wc -c)
+  # One CR for each of the two added header lines (name param is on the existing line).
+  [ "$out_cr" -eq "$((in_cr + 2))" ]
+}

--- a/test/send.bats
+++ b/test/send.bats
@@ -60,7 +60,7 @@ setup() {
 @test "send: allows short body with --allow-short" {
   run emails send user@example.com "Test Subject" "hi" --allow-short
   [ "$status" -eq 0 ]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 @test "send: sends with sufficient body length" {
@@ -68,7 +68,7 @@ setup() {
   run emails send user@example.com "Test Subject" "$body"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 # ============================================================================
@@ -82,14 +82,14 @@ setup() {
 
   # Check that himalaya was called and the MML included text/plain
   # (the mock just logs args, the actual MML goes via stdin which we can't easily capture)
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 @test "send: --html flag accepted" {
   local body="<h1>Hello</h1><p>This is an HTML email body that is definitely long enough to pass validation.</p>"
   run emails send user@example.com "Subject" --html "$body"
   [ "$status" -eq 0 ]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 # ============================================================================
@@ -101,7 +101,7 @@ setup() {
   echo "This is a message body loaded from a file, long enough to pass the minimum length check." > "$body_file"
   run emails send user@example.com "Subject" "$body_file"
   [ "$status" -eq 0 ]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 # ============================================================================
@@ -120,7 +120,7 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" != *"too short"* ]]
   [[ "$output" != *"body is required"* ]]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 # ============================================================================
@@ -165,7 +165,7 @@ setup() {
   run emails send --to user@example.com --subject "Explicit flags test" -b "$body"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
   mml=$(himalaya_stdin)
   [[ "$mml" == *"To: user@example.com"* ]]
   [[ "$mml" == *"Subject: Explicit flags test"* ]]
@@ -187,7 +187,7 @@ setup() {
   run emails send --to user@example.com --subject candi@example.com -b "$body"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
 }
 
 # ============================================================================
@@ -206,7 +206,7 @@ JSON
   run emails send --file "$spec"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to user@example.com"* ]]
-  assert_himalaya_called "template send"
+  assert_himalaya_called "message send"
   mml=$(himalaya_stdin)
   [[ "$mml" == *"To: user@example.com"* ]]
   [[ "$mml" == *"Subject: File spec test"* ]]
@@ -315,6 +315,55 @@ JSON
   run emails send --file "$spec" -b "extra body"
   [ "$status" -ne 0 ]
   [[ "$output" == *"already provides a body"* ]]
+}
+
+# ============================================================================
+# PGP signature naming (issue #28)
+# ============================================================================
+
+@test "send: compiles a pgpmime-signed template" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send user@example.com "Subject" "$body"
+  [ "$status" -eq 0 ]
+  assert_himalaya_called "template save"
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"sign=pgpmime"* ]]
+}
+
+@test "send: names the detached PGP signature attachment signature.asc" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send user@example.com "Subject" "$body"
+  [ "$status" -eq 0 ]
+  assert_himalaya_called "message send"
+
+  raw=$(himalaya_send_raw)
+  [[ "$raw" == *'Content-Type: application/pgp-signature; name="signature.asc"'* ]]
+  [[ "$raw" == *'Content-Disposition: attachment; filename="signature.asc"'* ]]
+  [[ "$raw" == *'Content-Description: OpenPGP digital signature'* ]]
+}
+
+@test "send: signature naming preserves the signed body and signature" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send user@example.com "Subject" "$body"
+  [ "$status" -eq 0 ]
+
+  raw=$(himalaya_send_raw)
+  # The clear part and armored signature must survive the rewrite untouched.
+  [[ "$raw" == *"mock signed body content"* ]]
+  [[ "$raw" == *"-----BEGIN PGP SIGNATURE-----"* ]]
+  [[ "$raw" == *"-----END PGP SIGNATURE-----"* ]]
+}
+
+@test "send: permanently purges the draft copies it created" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send user@example.com "Subject" "$body"
+  [ "$status" -eq 0 ]
+  # Drafts are flagged + expunged (permanent), not moved to Trash.
+  assert_himalaya_called "flag add"
+  assert_himalaya_called "folder expunge"
+  ! assert_himalaya_called "message delete"
+  # No draft ids should remain in the simulated Drafts folder.
+  [ -z "$(drafts_state)" ]
 }
 
 # ============================================================================


### PR DESCRIPTION
## Problem

Closes #28. Signed messages from `emails send` show the detached PGP signature as a **`noname`** attachment in clients like Gmail. The signature part is built by himalaya's mml compiler as a bare `application/pgp-signature` with **no `name`, `Content-Disposition`, or `Content-Description`** (`pimalaya/core` `mml/src/message/body/compiler/mod.rs:184`, unchanged on current master). There is no MML directive or himalaya config to override it, so bumping himalaya won't help — issue #28's "not controllable upstream" branch.

## Approach

`template send` compiles+signs+sends atomically, so we can't intercept its MIME. Instead the send path now:

1. `template save` to **Drafts** — the only no-send compile path; signs the message.
2. `message export --full` the raw signed MIME.
3. **Inject** `name="signature.asc"` + `Content-Disposition: attachment; filename="signature.asc"` + `Content-Description: OpenPGP digital signature` onto the signature part (`inject_signature_name` in `lib/email.sh`, a CRLF-preserving `awk` filter).
4. `message send` the rewritten raw (also saves the Sent copy, as before).
5. Permanently purge the transient draft copies (`flag … deleted` + `folder expunge`, not move-to-Trash).

Editing the signature part's **own** headers is safe: a PGP/MIME signature covers only the canonicalised clear part, never the signature part's MIME headers — so the signature stays valid (the integration test asserts `gpg --verify` still reports **Good signature** after the rewrite).

**Resilience:** if any step fails (e.g. no Drafts folder), it warns and falls back to the original `template send` so mail still goes out **signed** (just unnamed) rather than being dropped. A `trap` guarantees draft cleanup even on partial failure.

### Gotchas handled
- himalaya v1.2.0 `template save -o json` reads the template from an empty arg instead of stdin (`save.rs` `is_json` branch) → we call it **without** `-o json`.
- himalaya v1.2.0 `template save` double-saves the draft → cleanup diffs Drafts before/after and expunges every copy.
- `.mise/tasks/read`'s inbound attachment filter was broadened so a now-named `signature.asc`/`*.asc`/`*.pgp` is still dropped from the listing.

## Testing

All green locally:
- `mise run test` — 97/97 (incl. codebase lint). New: 4 `inject_signature_name` unit tests + 4 send-flow tests.
- `mise run test-integration` — 36/36. New end-to-end test provisions an ephemeral GPG key (so signing really happens), then asserts `multipart/signed` + `name="signature.asc"` + disposition/description, `gpg --verify` = Good signature, and Drafts **and** Trash are left clean.
- `bun test src/` — 44/44.

## Follow-up

Worth filing upstream on `pimalaya/core` to have the mml compiler set the signature filename natively (would let us drop this interception). Happy to open it.