### PR TITLE
fix(send): support multiple --to recipients (#41)

### DIFF
--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -112,12 +112,17 @@ if [ -n "${usage_file:-}" ]; then
   fi
 fi
 
-if [ -n "${usage_to:-}" ]; then
-  TOS=()
-  TO_COUNT=0
-  while IFS= read -r to; do
-    [ -n "$to" ] && TOS+=("$to") && TO_COUNT=$((TO_COUNT + 1))
-  done < <(printf '%s' "${usage_to:-}" | xargs printf '%s\n')
+_TO_FLAGS=()
+_TO_FCOUNT=0
+while IFS= read -r to; do
+  if [ -n "$to" ]; then
+    _TO_FLAGS+=("$to")
+    _TO_FCOUNT=$((_TO_FCOUNT + 1))
+  fi
+done < <(printf '%s' "${usage_to:-}" | xargs printf '%s\n')
+if [ "$_TO_FCOUNT" -gt 0 ]; then
+  TOS=("${_TO_FLAGS[@]}")
+  TO_COUNT="$_TO_FCOUNT"
 fi
 if [ -n "${usage_subject:-}" ]; then
   SUBJECT="$usage_subject"

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -33,31 +33,17 @@ json_string_field() {
   ' "$file"
 }
 
-json_cc_lines() {
+json_string_or_array_lines() {
   local file="$1"
-  jq -r '
-    if has("cc") and .cc != null then
-      if (.cc | type) == "array" then
-        if all(.cc[]; type == "string") then .cc[]
-        else error("cc array must contain only strings")
+  local field="$2"
+  jq -r --arg field "$field" '
+    if has($field) and .[$field] != null then
+      if (.[$field] | type) == "array" then
+        if all(.[$field][]; type == "string") then .[$field][]
+        else error($field + " array must contain only strings")
         end
-      elif (.cc | type) == "string" then .cc
-      else error("cc must be a string or array of strings")
-      end
-    else empty end
-  ' "$file"
-}
-
-json_to_lines() {
-  local file="$1"
-  jq -r '
-    if has("to") and .to != null then
-      if (.to | type) == "array" then
-        if all(.to[]; type == "string") then .to[]
-        else error("to array must contain only strings")
-        end
-      elif (.to | type) == "string" then .to
-      else error("to must be a string or array of strings")
+      elif (.[$field] | type) == "string" then .[$field]
+      else error($field + " must be a string or array of strings")
       end
     else empty end
   ' "$file"
@@ -83,7 +69,7 @@ if [ -n "${usage_file:-}" ]; then
     echo "Error: File not found: $usage_file"
     exit 1
   fi
-  if ! FILE_TO_LINES=$(json_to_lines "$usage_file"); then
+  if ! FILE_TO_LINES=$(json_string_or_array_lines "$usage_file" to); then
     echo "Error: invalid --file to field"
     exit 1
   fi
@@ -95,7 +81,7 @@ if [ -n "${usage_file:-}" ]; then
     echo "Error: invalid --file body field"
     exit 1
   fi
-  if ! FILE_CC_LINES=$(json_cc_lines "$usage_file"); then
+  if ! FILE_CC_LINES=$(json_string_or_array_lines "$usage_file" cc); then
     echo "Error: invalid --file cc field"
     exit 1
   fi

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -3,7 +3,7 @@
 #USAGE arg "[to_arg]" default="" help="Recipient email address (or use --to)"
 #USAGE arg "[subject_arg]" default="" help="Email subject (or use --subject)"
 #USAGE arg "[body_arg]" default="" help="Message body (optional, or use -b flag or stdin)"
-#USAGE flag "--to <to>" default="" help="Recipient email address (preferred over positional)"
+#USAGE flag "--to <to>" var=#true default="" help="Recipient email address (repeatable, preferred over positional)"
 #USAGE flag "--subject <subject>" default="" help="Email subject (preferred over positional)"
 #USAGE flag "-b --body <body>" default="" help="Message body (alternative to positional arg)"
 #USAGE flag "--file <file>" default="" help="JSON file with to/subject/body/cc fields"
@@ -48,9 +48,29 @@ json_cc_lines() {
   ' "$file"
 }
 
+json_to_lines() {
+  local file="$1"
+  jq -r '
+    if has("to") and .to != null then
+      if (.to | type) == "array" then
+        if all(.to[]; type == "string") then .to[]
+        else error("to array must contain only strings")
+        end
+      elif (.to | type) == "string" then .to
+      else error("to must be a string or array of strings")
+      end
+    else empty end
+  ' "$file"
+}
+
 # Resolution order: positionals < --file < explicit flags. The GHL guard only
 # applies to subjects resolved from the ambiguous positional slot.
-TO="${usage_to_arg:-}"
+TOS=()
+TO_COUNT=0
+if [ -n "${usage_to_arg:-}" ]; then
+  TOS+=("$usage_to_arg")
+  TO_COUNT=$((TO_COUNT + 1))
+fi
 SUBJECT="${usage_subject_arg:-}"
 SUBJECT_SOURCE=""
 [ -n "$SUBJECT" ] && SUBJECT_SOURCE="positional"
@@ -63,7 +83,7 @@ if [ -n "${usage_file:-}" ]; then
     echo "Error: File not found: $usage_file"
     exit 1
   fi
-  if ! _file_to=$(json_string_field "$usage_file" to); then
+  if ! FILE_TO_LINES=$(json_to_lines "$usage_file"); then
     echo "Error: invalid --file to field"
     exit 1
   fi
@@ -79,7 +99,13 @@ if [ -n "${usage_file:-}" ]; then
     echo "Error: invalid --file cc field"
     exit 1
   fi
-  [ -n "$_file_to" ] && TO="$_file_to"
+  if [ -n "$FILE_TO_LINES" ]; then
+    TOS=()
+    TO_COUNT=0
+    while IFS= read -r to; do
+      [ -n "$to" ] && TOS+=("$to") && TO_COUNT=$((TO_COUNT + 1))
+    done <<< "$FILE_TO_LINES"
+  fi
   if [ -n "$_file_subject" ]; then
     SUBJECT="$_file_subject"
     SUBJECT_SOURCE="file"
@@ -87,14 +113,23 @@ if [ -n "${usage_file:-}" ]; then
 fi
 
 if [ -n "${usage_to:-}" ]; then
-  TO="$usage_to"
+  TOS=()
+  TO_COUNT=0
+  while IFS= read -r to; do
+    [ -n "$to" ] && TOS+=("$to") && TO_COUNT=$((TO_COUNT + 1))
+  done < <(printf '%s' "${usage_to:-}" | xargs printf '%s\n')
 fi
 if [ -n "${usage_subject:-}" ]; then
   SUBJECT="$usage_subject"
   SUBJECT_SOURCE="flag"
 fi
 
-if [ -z "$TO" ] || [ -z "$SUBJECT" ]; then
+TO_ADDRS=""
+if [ "$TO_COUNT" -gt 0 ]; then
+  TO_ADDRS=$(printf '%s\n' "${TOS[@]}" | paste -sd ',' - | sed 's/,/, /g')
+fi
+
+if [ -z "$TO_ADDRS" ] || [ -z "$SUBJECT" ]; then
   echo "Usage: emails send --to <to> --subject <subject> [body options]"
   echo ""
   echo "Preferred (explicit flags):"
@@ -128,7 +163,7 @@ if [ "$SUBJECT_SOURCE" = "positional" ] && echo "$SUBJECT" | grep -qE '^[a-zA-Z0
   echo "Error: subject looks like an email address: '$SUBJECT'"
   echo "Did you accidentally pass two recipients positionally?"
   echo "Use --cc for additional recipients:"
-  echo "  emails send --to $TO --cc $SUBJECT --subject 'Your subject here' ..."
+  echo "  emails send --to ${TOS[0]} --cc $SUBJECT --subject 'Your subject here' ..."
   exit 1
 fi
 
@@ -264,7 +299,7 @@ esac
 
 emails_himalaya template send -a "$ACCOUNT" << EOF
 From: $FROM
-To: $TO
+To: $TO_ADDRS
 ${CC_HEADER:+$CC_HEADER
 }Subject: $SUBJECT
 
@@ -277,7 +312,7 @@ $ATTACH_MML
 EOF
 
 if [ -n "${CC_HEADER:-}" ]; then
-  echo "Sent to $TO (cc: $CC_ADDRS)"
+  echo "Sent to $TO_ADDRS (cc: $CC_ADDRS)"
 else
-  echo "Sent to $TO"
+  echo "Sent to $TO_ADDRS"
 fi

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ The README shows workflows, not a full command catalog. Use `emails <command> --
 
 ## Testing
 
-138 tests across two suites:
+145 tests across two suites:
 
-- **Unit tests (103)** — mock himalaya and test task logic in isolation
+- **Unit tests (110)** — mock himalaya and test task logic in isolation
 - **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip, no network
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 25](https://img.shields.io/badge/commands-25-blue?style=flat)
-[![tests: 145 passing](https://img.shields.io/badge/tests-145%20passing-brightgreen?style=flat)](test/)
+[![tests: 146 passing](https://img.shields.io/badge/tests-146%20passing-brightgreen?style=flat)](test/)
 ![lints: 9](https://img.shields.io/badge/lints-9-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -186,10 +186,10 @@ The README shows workflows, not a full command catalog. Use `emails <command> --
 
 ## Testing
 
-145 tests across two suites:
+146 tests across two suites:
 
 - **Unit tests (110)** — mock himalaya and test task logic in isolation
-- **Integration tests (35)** — real himalaya against a local maildir backend, full round-trip, no network
+- **Integration tests (36)** — real himalaya against a local maildir backend, full round-trip, no network
 
 ```bash
 mise run test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![commands: 25](https://img.shields.io/badge/commands-25-blue?style=flat)
-[![tests: 138 passing](https://img.shields.io/badge/tests-138%20passing-brightgreen?style=flat)](test/)
+[![tests: 145 passing](https://img.shields.io/badge/tests-145%20passing-brightgreen?style=flat)](test/)
 ![lints: 9](https://img.shields.io/badge/lints-9-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 

--- a/test/integration/send.bats
+++ b/test/integration/send.bats
@@ -117,6 +117,25 @@ HTML
   [[ "$output" == *"Explicit flags integration test"* ]]
 }
 
+@test "send: repeated --to flags preserve all To recipients" {
+  local body_file="$BATS_TEST_TMPDIR/body.txt"
+  echo "This message verifies repeated To recipients through the local maildir send path." > "$body_file"
+
+  emails send \
+    --to test-agent@ricon.family \
+    --to bob@example.com \
+    --subject "Repeated To integration test" \
+    -b "$body_file"
+
+  local sent_msg
+  sent_msg=$(find "$MAILDIR_ROOT/Sent" -type f | head -1)
+  run cat "$sent_msg"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"To:"* ]]
+  [[ "$output" == *"test-agent@ricon.family"* ]]
+  [[ "$output" == *"bob@example.com"* ]]
+}
+
 @test "send: rejects two recipient-looking positional args (GHL shape)" {
   run emails send alice@example.com candi@example.com \
     "This body is long enough but should never be sent because the subject is an email."

--- a/test/send.bats
+++ b/test/send.bats
@@ -9,10 +9,6 @@ setup() {
   setup_mock_himalaya
 }
 
-# ============================================================================
-# Argument validation
-# ============================================================================
-
 @test "send: fails without arguments" {
   run emails send
   [ "$status" -ne 0 ]
@@ -79,10 +75,6 @@ setup() {
   [[ "$mml" == *'From: "test-agent" <test-agent@ricon.family>'* ]]
 }
 
-# ============================================================================
-# HTML support
-# ============================================================================
-
 @test "send: passes text/plain content type by default" {
   local body="This is a message body that is definitely longer than fifty characters for testing."
   run emails send user@example.com "Subject" "$body"
@@ -100,10 +92,6 @@ setup() {
   assert_himalaya_called "template send"
 }
 
-# ============================================================================
-# Body from file
-# ============================================================================
-
 @test "send: reads body from file path" {
   local body_file="$BATS_TEST_TMPDIR/body.txt"
   echo "This is a message body loaded from a file, long enough to pass the minimum length check." > "$body_file"
@@ -111,10 +99,6 @@ setup() {
   [ "$status" -eq 0 ]
   assert_himalaya_called "template send"
 }
-
-# ============================================================================
-# Body from stdin
-# ============================================================================
 
 @test "send: reads body from stdin" {
   local body="This is a message body piped via stdin that is definitely longer than fifty characters."
@@ -130,10 +114,6 @@ setup() {
   [[ "$output" != *"body is required"* ]]
   assert_himalaya_called "template send"
 }
-
-# ============================================================================
-# Attachments
-# ============================================================================
 
 @test "send: rejects missing attachment file" {
   local body="This is a message body that is definitely longer than fifty characters for testing."
@@ -151,10 +131,6 @@ setup() {
   [[ "$output" == *"Attaching: doc.pdf"* ]]
 }
 
-# ============================================================================
-# GHL safety check
-# ============================================================================
-
 @test "send: rejects subject that looks like an email address" {
   local body="This is a message body that is definitely longer than fifty characters for testing."
   run emails send user@example.com candi@example.com "$body"
@@ -163,10 +139,6 @@ setup() {
   [[ "$output" == *"--cc"* ]]
   [ ! -s "$MOCK_HIMALAYA_CALLS" ]
 }
-
-# ============================================================================
-# Explicit --to / --subject flags
-# ============================================================================
 
 @test "send: --to and --subject flags work" {
   local body="This is a message body that is definitely longer than fifty characters for testing."
@@ -197,10 +169,6 @@ setup() {
   [[ "$output" == *"Sent to user@example.com"* ]]
   assert_himalaya_called "template send"
 }
-
-# ============================================================================
-# --file structured input
-# ============================================================================
 
 @test "send: --file JSON input sends message" {
   local spec="$BATS_TEST_TMPDIR/email.json"
@@ -325,9 +293,93 @@ JSON
   [[ "$output" == *"already provides a body"* ]]
 }
 
-# ============================================================================
-# Config
-# ============================================================================
+@test "send: multiple --to flags include both recipients in To header" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send --to alice@example.com --to bob@example.com --subject "Multiple TO test" -b "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to alice@example.com, bob@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: alice@example.com, bob@example.com"* ]]
+}
+
+@test "send: multiple --to flags show all recipients in output" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send --to first@example.com --to second@example.com --subject "Output test" -b "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to first@example.com, second@example.com"* ]]
+}
+
+@test "send: single --to flag still works" {
+  local body="This is a message body that is definitely longer than fifty characters for testing."
+  run emails send --to user@example.com --subject "Single TO test" -b "$body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  [[ "$output" != *","* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: user@example.com"* ]]
+}
+
+@test "send: --file JSON with array to field" {
+  local spec="$BATS_TEST_TMPDIR/email-array-to.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": ["alice@example.com", "bob@example.com"],
+  "subject": "Array TO file test",
+  "body": "This is the message body loaded from the JSON file spec for array TO testing."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to alice@example.com, bob@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: alice@example.com, bob@example.com"* ]]
+}
+
+@test "send: --file JSON with scalar to field still works" {
+  local spec="$BATS_TEST_TMPDIR/email-scalar-to.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": "user@example.com",
+  "subject": "Scalar TO file test",
+  "body": "This is the message body loaded from the JSON file spec for scalar TO testing."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sent to user@example.com"* ]]
+  mml=$(himalaya_stdin)
+  [[ "$mml" == *"To: user@example.com"* ]]
+}
+
+@test "send: --file JSON rejects non-string to array entries" {
+  local spec="$BATS_TEST_TMPDIR/email-bad-to.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": ["alice@example.com", 42],
+  "subject": "Bad TO field",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid --file to field"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
+
+@test "send: --file JSON rejects non-string non-array to" {
+  local spec="$BATS_TEST_TMPDIR/email-bad-to2.json"
+  cat > "$spec" <<'JSON'
+{
+  "to": 42,
+  "subject": "Bad TO field",
+  "body": "This is the message body loaded from the JSON file spec for structured agent email sending."
+}
+JSON
+  run emails send --file "$spec"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid --file to field"* ]]
+  [ ! -s "$MOCK_HIMALAYA_CALLS" ]
+}
 
 @test "send: fails without email config" {
   rm -f "$HIMALAYA_CONFIG"


### PR DESCRIPTION
Closes #41

Makes `--to` flag variadic (`var=#true`) so repeated `--to` flags no longer silently drop earlier recipients. Both `--to` flag and `--file` `to` field now accept multiple addresses.

### Changes

- **`.mise/tasks/send`** — Added `var=#true` to `--to` declaration; added `json_to_lines()` function mirroring `json_cc_lines()`; changed scalar `TO` to `TOS` array with full linear-overwrite precedence (positional < file < flags); `To:` header and output summary join multiple recipients with `, `
- **`test/send.bats`** — Added 7 regression tests covering multiple `--to` flags, `--file` array `to`, validation errors, and backward compatibility for single `--to` and scalar `--file` `to`; removed decorative section-header comments